### PR TITLE
Refuse to start when TLS initialization fails

### DIFF
--- a/src/openli_tls.c
+++ b/src/openli_tls.c
@@ -161,6 +161,10 @@ int create_ssl_context(openli_ssl_config_t *sslconf) {
 
     if (sslconf->certfile && sslconf->keyfile && sslconf->cacertfile) {
         sslconf->ctx = ssl_init(sslconf);
+        if (sslconf->ctx == NULL) {
+            logger(LOG_INFO, "OpenLI: TLS was requested but the SSL context could not be created -- refusing to continue unencrypted.");
+            return -1;
+        }
         logger(LOG_INFO, "OpenLI: creating new SSL context for TLS sessions");
         return 0;
     }


### PR DESCRIPTION
If `ssl_init()` fails (e.g. a typo'd certificate path), `create_ssl_context()` currently leaves `ctx` NULL, logs that an SSL context was created, and returns 0. `listen_ssl_socket()` then sees the NULL context and returns `OPENLI_SSL_CONNECT_NOSSL`, so the component starts and serves its configured port unencrypted while the log claims TLS is active.

This change returns -1 when `ssl_init()` returns NULL. All three components already abort on a negative return, so they now fail closed instead of silently falling back to plaintext.

Note this is a behavioural change: a deployment currently running with a broken certificate path starts (unencrypted) today, but will refuse to start after this change. Probably worth a mention in the release notes.

Reproduced on 60c106f: point `tlsca` at a non-existent file, start the provisioner, and `openssl s_client` connects with `Cipher is (NONE)` and no peer certificate.