### PR TITLE
 Fix crash and loss of TLS when reloading collector or mediator config

### DIFF
--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -2632,6 +2632,11 @@ static int reload_collector_config(collector_global_t *glob,
         goto endreload;
     }
 
+    if (create_ssl_context(&(newstate.sslconf)) < 0) {
+        ret = -1;
+        goto endreload;
+    }
+
     tlschanged = reload_ssl_config(&(glob->sslconf), &(newstate.sslconf));
 
     if (tlschanged == -1) {

--- a/src/collector/collector_sync.c
+++ b/src/collector/collector_sync.c
@@ -668,6 +668,10 @@ static int forward_provmsg_to_workers(void **zmq_socks, int sockcount,
 int sync_thread_send_provisioner_auth(collector_sync_t *sync) {
     char uuidstr[1024];
 
+    if (sync->outgoing == NULL) {
+        return 0;
+    }
+
     pthread_rwlock_rdlock(sync->info_mutex);
     /* Put our auth message onto the outgoing buffer */
     uuid_unparse(sync->info->uuid, uuidstr);

--- a/src/mediator/mediator.c
+++ b/src/mediator/mediator.c
@@ -1314,6 +1314,11 @@ static int reload_mediator_config(mediator_state_t *currstate) {
     /* Check if our TLS configuration has changed. If so, we'll need to
      * drop all connections to other OpenLI components and create them anew.
      */
+    if (create_ssl_context(&(newstate.sslconf)) < 0) {
+        clear_med_config(&newstate);
+        return -1;
+    }
+
     lock_med_collector_config(&(currstate->collector_threads.config));
     tlschanged = reload_ssl_config(&(currstate->sslconf), &(newstate.sslconf));
     unlock_med_collector_config(&(currstate->collector_threads.config));


### PR DESCRIPTION
Changing any TLS option on a running collector and sending SIGHUP segfaults it, and underneath the crash there's a quieter problem: neither the collector nor the mediator ever rebuilt their SSL context on reload, so a TLS config change reconnected everything unencrypted.

The crash. `reload_collector_config()` calls `sync_disconnect_provisioner()`, which frees the outgoing net buffer and NULLs it. Before the reconnect happens, the sync thread runs `sync_thread_publish_reload()` → `sync_thread_send_provisioner_auth()`, which pushes an auth message onto that NULL buffer. There is no connection to send an auth message on at that point anyway — the reconnect on the following loop iteration sends its own. Fixed by returning early from `sync_thread_send_provisioner_auth()` when there is no current provisioner connection. This is the collector_sync.c half of the guard discussed in #125's follow-up; it complements the guard added to `push_generic_onto_net_buffer()` in 35b0974 rather than replacing it.

The TLS loss. `reload_ssl_config()` takes the SSL context from the incoming (freshly parsed) config, but only the provisioner ever creates one on reload, via `init_prov_state()`. The collector and mediator were replacing a working context with NULL and carrying on in plaintext — the crash was masking this. Fixed by calling `create_ssl_context()` on the incoming config in `reload_collector_config()` and `reload_mediator_config()`, matching what the provisioner already does. When the TLS config turns out to be unchanged, the extra context is freed by the existing `clear_global_config()` / `clear_med_config()` cleanup.

Reproduction: rotate `tlscert` on a running collector and send SIGHUP — a routine operation, given `createCerts` issues 365-day certificates. Before: segfault. After: collector drops its provisioner/mediator connections and re-establishes them over TLS with the new cert.