### PR TITLE
mediator: batch CC and RAWIP records in RabbitMQ

### DIFF
--- a/src/mediator/coll_recv_thread.c
+++ b/src/mediator/coll_recv_thread.c
@@ -237,25 +237,30 @@ int collrecv_save_message(coll_recv_t *col, unsigned char *liid,
             return -1;
         }
         sav = &(col->saved_cc_msgs[col->saved_cc_msg_cnt]);
-        nexttag = &(col->ccs_published);
+        nexttag = NULL;
         col->saved_cc_msg_cnt ++;
     } else {
         if (col->saved_raw_msg_cnt == MAX_SAVED_RECEIVED_DATA) {
             return -1;
         }
         sav = &(col->saved_raw_msgs[col->saved_raw_msg_cnt]);
-        nexttag = &(col->raw_published);
+        nexttag = NULL;
         col->saved_raw_msg_cnt ++;
     }
 
     /* TODO replace constant calloc/free with "retained" buffers that get
      * expanded if necessary but otherwise recycled
      */
-    (*nexttag)++;
     sav->liid = strdup((const char *)liid);
     sav->msglen = msglen;
     sav->msgtype = msgtype;
-    sav->delivtag = *nexttag;
+    if (nexttag) {
+        (*nexttag)++;
+        sav->delivtag = *nexttag;
+    } else {
+        /* CC and RAWIP get a delivery tag when their batch is published. */
+        sav->delivtag = 0;
+    }
     sav->msgbody = calloc(sav->msglen, sizeof(uint8_t));
 
     memcpy(sav->msgbody, msgbody, msglen);
@@ -569,18 +574,12 @@ static int _process_received_data(coll_recv_t *col, uint8_t *msgbody,
     found->lastseen = tv.tv_sec;
 
     /* Hand off to publishing methods defined in mediator_rmq.c */
+    /* CC is published in batches at the end of this receive pass.
+     * collrecv_save_message() has already retained this record.
+     */
     if (msgtype == OPENLI_PROTO_ETSI_CC) {
         if (found->declared_int_rmq) {
-            r = publish_cc_on_mediator_liid_RMQ_queue(col->amqp_producer_state,
-                    msgbody, msglen,
-                    found->liid, found->queuenames[1], &(col->rmq_blocked));
-            if (r < 0) {
-                logger(LOG_INFO, "OpenLI Mediator: collector thread for %s has disconnected from local RMQ instance after failing to publish a CC", col->ipaddr);
-                amqp_destroy_connection(col->amqp_producer_state);
-                col->amqp_producer_state = NULL;
-                r = 0;
-
-            }
+            r = 1;
         } else {
             increment_col_drop_counter(col);
             r = 0;
@@ -618,17 +617,11 @@ static int _process_received_data(coll_recv_t *col, uint8_t *msgbody,
                 found->declared_raw_rmq = 1;
             }
         }
-        /* publish to raw IP queue */
+        /* RAWIP is published in batches at the end of this receive pass.
+         * collrecv_save_message() has already retained this record.
+         */
         if (found->declared_raw_rmq) {
-            r = publish_rawip_on_mediator_liid_RMQ_queue(
-                    col->amqp_producer_state, msgbody, msglen, found->liid,
-                    found->queuenames[2], &(col->rmq_blocked));
-            if (r < 0) {
-                logger(LOG_INFO, "OpenLI Mediator: collector thread for %s has disconnected from local RMQ instance after failing to publish raw data", col->ipaddr);
-                amqp_destroy_connection(col->amqp_producer_state);
-                col->amqp_producer_state = NULL;
-                r = 0;
-            }
+            r = 1;
         } else {
             increment_col_drop_counter(col);
             r = 0;
@@ -637,6 +630,134 @@ static int _process_received_data(coll_recv_t *col, uint8_t *msgbody,
 
     return r;
 
+}
+
+static int publish_pending_cc_batches(coll_recv_t *col) {
+    openli_cc_batch_record_t records[OPENLI_CC_BATCH_MAX_RECORDS];
+    size_t indexes[OPENLI_CC_BATCH_MAX_RECORDS];
+    size_t i;
+
+    for (i = 0; i < col->saved_cc_msg_cnt; i++) {
+        saved_received_data_t *first = &(col->saved_cc_msgs[i]);
+        col_known_liid_t *known = NULL;
+        size_t bodylen = 8;
+        uint16_t count = 0;
+        size_t j;
+        int r;
+
+        if (first->msgbody == NULL || first->delivtag != 0) {
+            continue;
+        }
+
+        HASH_FIND(hh, col->known_liids, first->liid, strlen(first->liid),
+                known);
+        if (known == NULL || !known->declared_int_rmq) {
+            return 0;
+        }
+
+        for (j = i; j < col->saved_cc_msg_cnt &&
+                count < OPENLI_CC_BATCH_MAX_RECORDS; j++) {
+            saved_received_data_t *candidate = &(col->saved_cc_msgs[j]);
+
+            if (candidate->msgbody == NULL || candidate->delivtag != 0 ||
+                    strcmp(candidate->liid, first->liid) != 0) {
+                continue;
+            }
+            if (bodylen > OPENLI_CC_BATCH_MAX_BYTES - 2U -
+                    candidate->msglen) {
+                break;
+            }
+
+            records[count].body = candidate->msgbody;
+            records[count].len = candidate->msglen;
+            indexes[count] = j;
+            bodylen += 2U + candidate->msglen;
+            count++;
+        }
+
+        if (count == 0) {
+            return 0;
+        }
+
+        r = publish_cc_batch_on_mediator_liid_RMQ_queue(
+                col->amqp_producer_state, records, count, first->liid,
+                known->queuenames[1], &(col->rmq_blocked));
+        if (r <= 0) {
+            return r;
+        }
+
+
+        col->ccs_published++;
+        for (j = 0; j < count; j++) {
+            col->saved_cc_msgs[indexes[j]].delivtag = col->ccs_published;
+        }
+    }
+
+    return 1;
+}
+
+static int publish_pending_raw_batches(coll_recv_t *col) {
+    openli_rawip_batch_record_t records[OPENLI_RAWIP_BATCH_MAX_RECORDS];
+    size_t indexes[OPENLI_RAWIP_BATCH_MAX_RECORDS];
+    size_t i;
+
+    for (i = 0; i < col->saved_raw_msg_cnt; i++) {
+        saved_received_data_t *first = &(col->saved_raw_msgs[i]);
+        col_known_liid_t *known = NULL;
+        size_t bodylen = 8;
+        uint16_t count = 0;
+        size_t j;
+        int r;
+
+        if (first->msgbody == NULL || first->delivtag != 0) {
+            continue;
+        }
+
+        HASH_FIND(hh, col->known_liids, first->liid, strlen(first->liid),
+                known);
+        if (known == NULL || !known->declared_raw_rmq) {
+            return 0;
+        }
+
+        for (j = i; j < col->saved_raw_msg_cnt &&
+                count < OPENLI_RAWIP_BATCH_MAX_RECORDS; j++) {
+            saved_received_data_t *candidate = &(col->saved_raw_msgs[j]);
+
+            if (candidate->msgbody == NULL || candidate->delivtag != 0 ||
+                    strcmp(candidate->liid, first->liid) != 0) {
+                continue;
+            }
+            if (bodylen > OPENLI_RAWIP_BATCH_MAX_BYTES - 2U -
+                    candidate->msglen) {
+                break;
+            }
+
+            records[count].body = candidate->msgbody;
+            records[count].len = candidate->msglen;
+            indexes[count] = j;
+            bodylen += 2U + candidate->msglen;
+            count++;
+        }
+
+        if (count == 0) {
+            return 0;
+        }
+
+        r = publish_rawip_batch_on_mediator_liid_RMQ_queue(
+                col->amqp_producer_state, records, count, first->liid,
+                known->queuenames[2], &(col->rmq_blocked));
+        if (r <= 0) {
+            return r;
+        }
+
+
+        col->raw_published++;
+        for (j = 0; j < count; j++) {
+            col->saved_raw_msgs[indexes[j]].delivtag = col->raw_published;
+        }
+    }
+
+    return 1;
 }
 
 static int process_saved_messages(coll_recv_t *col,
@@ -680,15 +801,27 @@ static int process_all_saved_messages(coll_recv_t *col) {
     }
 
     if (col->saved_cc_msg_cnt > 0) {
-        if ((r = process_saved_messages(col, col->saved_cc_msgs,
-                &(col->saved_cc_msg_cnt), &(col->ccs_published))) <= 0) {
+        size_t i;
+        for (i = 0; i < col->saved_cc_msg_cnt; i++) {
+            if (col->saved_cc_msgs[i].msgbody) {
+                col->saved_cc_msgs[i].delivtag = 0;
+            }
+        }
+        col->ccs_published = 0;
+        if ((r = publish_pending_cc_batches(col)) <= 0) {
             return r;
         }
     }
 
     if (col->saved_raw_msg_cnt > 0) {
-        if ((r = process_saved_messages(col, col->saved_raw_msgs,
-                &(col->saved_raw_msg_cnt), &(col->raw_published))) <= 0) {
+        size_t i;
+        for (i = 0; i < col->saved_raw_msg_cnt; i++) {
+            if (col->saved_raw_msgs[i].msgbody) {
+                col->saved_raw_msgs[i].delivtag = 0;
+            }
+        }
+        col->raw_published = 0;
+        if ((r = publish_pending_raw_batches(col)) <= 0) {
             return r;
         }
     }
@@ -847,8 +980,20 @@ static int receive_collector(coll_recv_t *col, openli_epoll_ev_t *mev) {
 
 
 processacks:
+    if (col->amqp_producer_state && col->saved_cc_msg_cnt > 0 &&
+            publish_pending_cc_batches(col) <= 0) {
+        amqp_destroy_connection(col->amqp_producer_state);
+        col->amqp_producer_state = NULL;
+    }
+
+    if (col->amqp_producer_state && col->saved_raw_msg_cnt > 0 &&
+            publish_pending_raw_batches(col) <= 0) {
+        amqp_destroy_connection(col->amqp_producer_state);
+        col->amqp_producer_state = NULL;
+    }
+
     if (col->amqp_producer_state &&
-            COLL_OUTSTANDING_PUB_CONFIRMS(col) && 
+            COLL_OUTSTANDING_PUB_CONFIRMS(col) &&
             consume_mediator_RMQ_producer_acks(col) == 0) {
         /* RMQ failed to acknowledge everything we published, have to
          * reconnect and re-publish

--- a/src/mediator/coll_recv_thread.h
+++ b/src/mediator/coll_recv_thread.h
@@ -52,7 +52,7 @@
  *
  */
 
-#define MAX_SAVED_RECEIVED_DATA 256
+#define MAX_SAVED_RECEIVED_DATA 1024
 
 /** Types of messages that can be sent between the main mediator thread and a
  *  collector receive thread.

--- a/src/mediator/lea_send_thread.c
+++ b/src/mediator/lea_send_thread.c
@@ -28,6 +28,12 @@
 #include <assert.h>
 #include "logger.h"
 #include "lea_send_thread.h"
+
+/* Consume more records per RMQ round-trip. The socket send path already
+ * applies a 16 MiB fairness cap, so this raises throughput without allowing
+ * one handover to monopolise the agency thread indefinitely. */
+#define LEA_RMQ_BATCH_SIZE 1024
+
 #include "mediator_rmq.h"
 #include "handover.h"
 #include "agency.h"
@@ -413,7 +419,8 @@ static int consume_available_rmq_records(handover_t *ho,
     /* Otherwise, read some new messages from RMQ and try to send those */
     if (ho->handover_type == HANDOVER_HI3) {
         r = consume_mediator_cc_messages(ho->rmq_consumer,
-                &(ho->ho_state->buf), 100, &(ho->ho_state->next_rmq_ack));
+                &(ho->ho_state->buf), LEA_RMQ_BATCH_SIZE,
+                &(ho->ho_state->next_rmq_ack));
         if (r < 0) {
             reset_handover_rmq(ho);
             logger(LOG_INFO, "OpenLI Mediator: error while consuming CC messages from internal queue by agency %s", state->agencyid);
@@ -423,7 +430,8 @@ static int consume_available_rmq_records(handover_t *ho,
         }
     } else if (ho->handover_type == HANDOVER_HI2) {
         r = consume_mediator_iri_messages(ho->rmq_consumer,
-                &(ho->ho_state->buf), 100, &(ho->ho_state->next_rmq_ack));
+                &(ho->ho_state->buf), LEA_RMQ_BATCH_SIZE,
+                &(ho->ho_state->next_rmq_ack));
         if (r < 0) {
             reset_handover_rmq(ho);
             logger(LOG_INFO, "OpenLI Mediator: error while consuming IRI messages from internal queue by agency %s", state->agencyid);

--- a/src/mediator/mediator_rmq.c
+++ b/src/mediator/mediator_rmq.c
@@ -241,7 +241,7 @@ int declare_mediator_rawip_RMQ_queue(amqp_connection_state_t state,
  *  @return 0 if an error occurs, 1 if the message is published successfully
  */
 static int produce_mediator_RMQ(amqp_connection_state_t state,
-        uint8_t *msg, uint16_t msglen, char *liid, int channel,
+        uint8_t *msg, size_t msglen, char *liid, int channel,
         const char *queuename, uint32_t expiry, uint8_t *is_blocked) {
     amqp_bytes_t message_bytes;
     amqp_basic_properties_t props;
@@ -291,6 +291,67 @@ int publish_rawip_on_mediator_liid_RMQ_queue(amqp_connection_state_t state,
             is_blocked);
 }
 
+
+/*
+ * Stage 2 RAWIP batch body:
+ *   uint32_t magic (OPENLI_RAWIP_BATCH_MAGIC)
+ *   uint8_t  version
+ *   uint8_t  reserved
+ *   uint16_t record_count
+ *   repeated { uint16_t record_length; uint8_t record[record_length]; }
+ * All integer fields are network byte order.
+ */
+int publish_rawip_batch_on_mediator_liid_RMQ_queue(
+        amqp_connection_state_t state,
+        const openli_rawip_batch_record_t *records, uint16_t record_count,
+        char *liid, const char *queuename, uint8_t *is_blocked) {
+    uint8_t *body;
+    uint8_t *cursor;
+    uint32_t magic;
+    uint16_t count_be;
+    size_t bodylen = 8;
+    uint16_t i;
+    int ret;
+
+    if (records == NULL || record_count == 0 ||
+            record_count > OPENLI_RAWIP_BATCH_MAX_RECORDS) {
+        return -1;
+    }
+
+    for (i = 0; i < record_count; i++) {
+        if (records[i].body == NULL || records[i].len == 0 ||
+                bodylen > OPENLI_RAWIP_BATCH_MAX_BYTES - 2U - records[i].len) {
+            return -1;
+        }
+        bodylen += 2U + records[i].len;
+    }
+
+    body = malloc(bodylen);
+    if (body == NULL) {
+        return -1;
+    }
+
+    cursor = body;
+    magic = htonl(OPENLI_RAWIP_BATCH_MAGIC);
+    memcpy(cursor, &magic, sizeof(magic)); cursor += sizeof(magic);
+    *cursor++ = OPENLI_RAWIP_BATCH_VERSION;
+    *cursor++ = 0;
+    count_be = htons(record_count);
+    memcpy(cursor, &count_be, sizeof(count_be)); cursor += sizeof(count_be);
+
+    for (i = 0; i < record_count; i++) {
+        uint16_t len_be = htons(records[i].len);
+        memcpy(cursor, &len_be, sizeof(len_be)); cursor += sizeof(len_be);
+        memcpy(cursor, records[i].body, records[i].len);
+        cursor += records[i].len;
+    }
+
+    ret = produce_mediator_RMQ(state, body, bodylen, liid, 4, queuename, 0,
+            is_blocked);
+    free(body);
+    return ret;
+}
+
 /** Publishes an encoded IRI onto a mediator RMQ queue.
  *
  *  @param state            The RMQ connection to use to publish the message
@@ -327,6 +388,66 @@ int publish_cc_on_mediator_liid_RMQ_queue(amqp_connection_state_t state,
 
     return produce_mediator_RMQ(state, msg, msglen, liid, 3, queuename, 0,
             is_blocked);
+}
+
+/*
+ * Stage 3 CC batch body:
+ *   uint32_t magic (OPENLI_CC_BATCH_MAGIC)
+ *   uint8_t  version
+ *   uint8_t  reserved
+ *   uint16_t record_count
+ *   repeated { uint16_t record_length; uint8_t record[record_length]; }
+ * All integer fields are network byte order.
+ */
+int publish_cc_batch_on_mediator_liid_RMQ_queue(
+        amqp_connection_state_t state,
+        const openli_cc_batch_record_t *records, uint16_t record_count,
+        char *liid, const char *queuename, uint8_t *is_blocked) {
+    uint8_t *body;
+    uint8_t *cursor;
+    uint32_t magic;
+    uint16_t count_be;
+    size_t bodylen = 8;
+    uint16_t i;
+    int ret;
+
+    if (records == NULL || record_count == 0 ||
+            record_count > OPENLI_CC_BATCH_MAX_RECORDS) {
+        return -1;
+    }
+
+    for (i = 0; i < record_count; i++) {
+        if (records[i].body == NULL || records[i].len == 0 ||
+                bodylen > OPENLI_CC_BATCH_MAX_BYTES - 2U - records[i].len) {
+            return -1;
+        }
+        bodylen += 2U + records[i].len;
+    }
+
+    body = malloc(bodylen);
+    if (body == NULL) {
+        return -1;
+    }
+
+    cursor = body;
+    magic = htonl(OPENLI_CC_BATCH_MAGIC);
+    memcpy(cursor, &magic, sizeof(magic)); cursor += sizeof(magic);
+    *cursor++ = OPENLI_CC_BATCH_VERSION;
+    *cursor++ = 0;
+    count_be = htons(record_count);
+    memcpy(cursor, &count_be, sizeof(count_be)); cursor += sizeof(count_be);
+
+    for (i = 0; i < record_count; i++) {
+        uint16_t len_be = htons(records[i].len);
+        memcpy(cursor, &len_be, sizeof(len_be)); cursor += sizeof(len_be);
+        memcpy(cursor, records[i].body, records[i].len);
+        cursor += records[i].len;
+    }
+
+    ret = produce_mediator_RMQ(state, body, bodylen, liid, 3, queuename, 0,
+            is_blocked);
+    free(body);
+    return ret;
 }
 
 void remove_mediator_liid_RMQ_queue(amqp_connection_state_t state,
@@ -912,67 +1033,69 @@ static int consume_other_frame(amqp_connection_state_t state) {
     return -1;
 }
 
-int consume_mediator_RMQ_producer_acks(coll_recv_t *col) {
-
+static int count_saved_messages(saved_received_data_t *msgs, size_t msgcnt) {
     size_t i;
+    int awaiting = 0;
+
+    for (i = 0; i < msgcnt; i++) {
+        if (msgs[i].msgbody != NULL && msgs[i].msglen > 0) {
+            awaiting++;
+        }
+    }
+    return awaiting;
+}
+
+static int release_confirmed_messages(saved_received_data_t *msgs,
+        size_t msgcnt, uint64_t delivery_tag, uint8_t multiple) {
+    size_t i;
+    int released = 0;
+
+    for (i = 0; i < msgcnt; i++) {
+        saved_received_data_t *next = &(msgs[i]);
+        int confirmed;
+
+        if (next->msgbody == NULL || next->msglen == 0 ||
+                next->delivtag == 0) {
+            continue;
+        }
+        confirmed = multiple ? next->delivtag <= delivery_tag :
+                next->delivtag == delivery_tag;
+        if (!confirmed) {
+            continue;
+        }
+        free(next->msgbody);
+        free(next->liid);
+        next->msgbody = NULL;
+        next->liid = NULL;
+        next->msglen = 0;
+        next->delivtag = 0;
+        released++;
+    }
+    return released;
+}
+
+int consume_mediator_RMQ_producer_acks(coll_recv_t *col) {
     int r;
     amqp_frame_t frame;
-    saved_received_data_t *sav;
     struct timeval tv;
-
     int cc_await = 0, iri_await = 0, raw_await = 0;
-    int iri_start = -1, cc_start = -1, raw_start = -1;
 
-    for (i = 0; i < col->saved_iri_msg_cnt; i++) {
-        if (col->saved_iri_msgs[i].msglen > 0) {
-            iri_await ++;
-            if (iri_start < 0) {
-                iri_start = i;
-            }
-        }
-    }
-
-    for (i = 0; i < col->saved_cc_msg_cnt; i++) {
-        if (col->saved_cc_msgs[i].msglen > 0) {
-            cc_await ++;
-            if (cc_start < 0) {
-                cc_start = i;
-            }
-        }
-    }
-
-    for (i = 0; i < col->saved_raw_msg_cnt; i++) {
-        if (col->saved_raw_msgs[i].msglen > 0) {
-            raw_await ++;
-            if (raw_start < 0) {
-                raw_start = i;
-            }
-        }
-    }
+    iri_await = count_saved_messages(col->saved_iri_msgs,
+            col->saved_iri_msg_cnt);
+    cc_await = count_saved_messages(col->saved_cc_msgs,
+            col->saved_cc_msg_cnt);
+    raw_await = count_saved_messages(col->saved_raw_msgs,
+            col->saved_raw_msg_cnt);
 
     while (cc_await > 0 || iri_await > 0 || raw_await > 0) {
-        /* keep consuming until we get an ACK or a NACK -- everything else
-         * can just be ignored (note that this will block until we get what
-         * we are looking for, or the connection fails).
-         */
-        tv.tv_sec = 1; tv.tv_usec = 0;
+        tv.tv_sec = 1;
+        tv.tv_usec = 0;
         r = amqp_simple_wait_frame_noblock(col->amqp_producer_state, &frame,
                 &tv);
-
         if (r == AMQP_STATUS_TIMEOUT) {
-            /* No acknowledgements this second, we need to move on instead so
-             * that we're not blocking and hope that something turns up
-             * next time we check for acks.
-             */
-            if (cc_await == 0) {
-                col->saved_cc_msg_cnt = 0;
-            }
-            if (iri_await == 0) {
-                col->saved_iri_msg_cnt = 0;
-            }
-            if (raw_await == 0) {
-                col->saved_raw_msg_cnt = 0;
-            }
+            if (cc_await == 0) col->saved_cc_msg_cnt = 0;
+            if (iri_await == 0) col->saved_iri_msg_cnt = 0;
+            if (raw_await == 0) col->saved_raw_msg_cnt = 0;
             if (col->saved_raw_msg_cnt < MAX_SAVED_RECEIVED_DATA &&
                     col->saved_iri_msg_cnt < MAX_SAVED_RECEIVED_DATA &&
                     col->saved_cc_msg_cnt < MAX_SAVED_RECEIVED_DATA) {
@@ -980,96 +1103,70 @@ int consume_mediator_RMQ_producer_acks(coll_recv_t *col) {
             }
             return 1;
         } else if (r != AMQP_STATUS_OK) {
-            /* broker failure, must retry */
             return 0;
         }
 
         if (frame.frame_type == AMQP_FRAME_METHOD) {
             amqp_basic_ack_t *ack;
-
             switch(frame.payload.method.id) {
                 case AMQP_CONNECTION_CLOSE_METHOD:
-                    logger(LOG_INFO,
-                            "OpenLI mediator: 'close' exception occurred on an internal RMQ connection -- must restart connection");
+                    logger(LOG_INFO, "OpenLI mediator: 'close' exception occurred on an internal RMQ connection -- must restart connection");
                     return 0;
                 case AMQP_CHANNEL_CLOSE_METHOD:
-                    logger(LOG_INFO,
-                            "OpenLI mediator: channel exception occurred on an internal RMQ connection -- must reset connection");
+                    logger(LOG_INFO, "OpenLI mediator: channel exception occurred on an internal RMQ connection -- must reset connection");
                     return 0;
-                case AMQP_BASIC_ACK_METHOD:
-                    ack = (amqp_basic_ack_t *)frame.payload.method.decoded;
-                    int *start, *await;
+                case AMQP_BASIC_ACK_METHOD: {
+                    saved_received_data_t *msgs;
+                    size_t msgcnt;
+                    int *await;
+                    int released;
 
+                    ack = (amqp_basic_ack_t *)frame.payload.method.decoded;
                     if (frame.channel == 2) {
-                        sav = col->saved_iri_msgs;
-                        start = &(iri_start);
+                        msgs = col->saved_iri_msgs;
+                        msgcnt = col->saved_iri_msg_cnt;
                         await = &(iri_await);
                     } else if (frame.channel == 3) {
-                        sav = col->saved_cc_msgs;
-                        start = &(cc_start);
+                        msgs = col->saved_cc_msgs;
+                        msgcnt = col->saved_cc_msg_cnt;
                         await = &(cc_await);
-
                     } else if (frame.channel == 4) {
-                        sav = col->saved_raw_msgs;
-                        start = &(raw_start);
+                        msgs = col->saved_raw_msgs;
+                        msgcnt = col->saved_raw_msg_cnt;
                         await = &(raw_await);
-
                     } else {
                         break;
                     }
-                    while (*start < MAX_SAVED_RECEIVED_DATA && *await > 0) {
-                        saved_received_data_t *next = &(sav[*start]);
-
-                        if (next->delivtag > ack->delivery_tag) {
-                            break;
-                        }
-                        if (next->msgbody) {
-                            free(next->msgbody);
-                            next->msgbody = NULL;
-                        }
-                        if (next->liid) {
-                            free(next->liid);
-                            next->liid = NULL;
-                        }
-                        next->msglen = 0;
-                        next->delivtag = 0;
-                        (*start)++;
-                        (*await)--;
-                    }
-
+                    released = release_confirmed_messages(msgs, msgcnt,
+                            ack->delivery_tag, ack->multiple);
+                    assert(released <= *await);
+                    *await -= released;
                     break;
-
+                }
                 case AMQP_BASIC_NACK_METHOD:
                     return 0;
                 case AMQP_CONNECTION_BLOCKED_METHOD:
-                    if ((col->rmq_blocked) == 0) {
-                        logger(LOG_INFO,
-                                "OpenLI mediator: RMQ is unable to handle any more published ETSI records!");
-                        logger(LOG_INFO,
-                                "OpenLI mediator: this is a SERIOUS problem -- received ETSI records are going to be dropped!");
+                    if (col->rmq_blocked == 0) {
+                        logger(LOG_INFO, "OpenLI mediator: RMQ is unable to handle any more published ETSI records!");
+                        logger(LOG_INFO, "OpenLI mediator: this is a SERIOUS problem -- received ETSI records are going to be dropped!");
                     }
                     col->rmq_blocked = 1;
                     break;
                 case AMQP_CONNECTION_UNBLOCKED_METHOD:
-                    if ((col->rmq_blocked) == 1) {
-                        logger(LOG_INFO,
-                                "OpenLI mediator: RMQ has become unblocked and will resume publishing ETSI records.");
+                    if (col->rmq_blocked == 1) {
+                        logger(LOG_INFO, "OpenLI mediator: RMQ has become unblocked and will resume publishing ETSI records.");
                     }
                     col->rmq_blocked = 0;
                     break;
             }
         }
     }
-
-    /* all messages were acknowledged */
     col->saved_iri_msg_cnt = 0;
     col->saved_raw_msg_cnt = 0;
     col->saved_cc_msg_cnt = 0;
     col->queue_full = 0;
     return 1;
-
 }
-
 
 #define MAX_CONSUMER_REJECTIONS 10
 
@@ -1172,10 +1269,87 @@ static int consume_mediator_liid_messages(amqp_connection_state_t state,
 
         msgread += 1;
 
-        /* Raw IP messages need to be prepended with their length as we have
-         * no other reliable indicator of their length in the message
-         * itself.
+        /* RAWIP and CC accept both their legacy one-record bodies and their
+         * versioned batch bodies. IRI remains unchanged.
          */
+        if (envelope.message.body.len >= 8) {
+            uint8_t *cursor = envelope.message.body.bytes;
+            uint8_t *end = cursor + envelope.message.body.len;
+            uint32_t magic_be;
+            uint32_t magic;
+            uint16_t count_be;
+            uint16_t count;
+            uint16_t recno;
+            uint16_t max_records = 0;
+            uint8_t batch_version = 0;
+            uint8_t is_rawip_batch = 0;
+            uint8_t is_cc_batch = 0;
+
+            memcpy(&magic_be, cursor, sizeof(magic_be));
+            magic = ntohl(magic_be);
+            if (prependlength && magic == OPENLI_RAWIP_BATCH_MAGIC) {
+                batch_version = OPENLI_RAWIP_BATCH_VERSION;
+                max_records = OPENLI_RAWIP_BATCH_MAX_RECORDS;
+                is_rawip_batch = 1;
+            } else if (!prependlength && channel == 3 &&
+                    magic == OPENLI_CC_BATCH_MAGIC) {
+                batch_version = OPENLI_CC_BATCH_VERSION;
+                max_records = OPENLI_CC_BATCH_MAX_RECORDS;
+                is_cc_batch = 1;
+            }
+
+            if ((is_rawip_batch || is_cc_batch) &&
+                    cursor[4] == batch_version) {
+                memcpy(&count_be, cursor + 6, sizeof(count_be));
+                count = ntohs(count_be);
+                cursor += 8;
+
+                if (count == 0 || count > max_records) {
+                    amqp_destroy_envelope(&envelope);
+                    return -1;
+                }
+
+                for (recno = 0; recno < count; recno++) {
+                    uint16_t rec_len_be;
+                    uint16_t rec_len;
+
+                    if ((size_t)(end - cursor) < sizeof(rec_len_be)) {
+                        amqp_destroy_envelope(&envelope);
+                        return -1;
+                    }
+                    memcpy(&rec_len_be, cursor, sizeof(rec_len_be));
+                    cursor += sizeof(rec_len_be);
+                    rec_len = ntohs(rec_len_be);
+                    if (rec_len == 0 || (size_t)(end - cursor) < rec_len) {
+                        amqp_destroy_envelope(&envelope);
+                        return -1;
+                    }
+
+                    if (is_rawip_batch) {
+                        len = rec_len;
+                        if (append_etsipdu_to_buffer(buf, (uint8_t *)&len,
+                                sizeof(len), 0) == 0) {
+                            amqp_destroy_envelope(&envelope);
+                            return -1;
+                        }
+                    }
+                    if (append_etsipdu_to_buffer(buf, cursor, rec_len, 0) == 0) {
+                        amqp_destroy_envelope(&envelope);
+                        return -1;
+                    }
+                    cursor += rec_len;
+                }
+
+                if (cursor != end) {
+                    amqp_destroy_envelope(&envelope);
+                    return -1;
+                }
+                *last_deliv = envelope.delivery_tag;
+                amqp_destroy_envelope(&envelope);
+                continue;
+            }
+        }
+
         if (prependlength) {
             len = envelope.message.body.len;
             if (append_etsipdu_to_buffer(buf, (uint8_t *)(&len),

--- a/src/mediator/mediator_rmq.h
+++ b/src/mediator/mediator_rmq.h
@@ -42,6 +42,37 @@
 #include "coll_recv_thread.h"
 #include "lea_send_thread.h"
 
+/* Stage 2 RAWIP batch wire format. Multi-byte fields are network byte order. */
+#define OPENLI_RAWIP_BATCH_MAGIC 0x4f4c5242U /* "OLRB" */
+#define OPENLI_RAWIP_BATCH_VERSION 1U
+#define OPENLI_RAWIP_BATCH_MAX_RECORDS 1024U
+#define OPENLI_RAWIP_BATCH_MAX_BYTES (2U * 1024U * 1024U)
+
+typedef struct openli_rawip_batch_record {
+    const uint8_t *body;
+    uint16_t len;
+} openli_rawip_batch_record_t;
+
+/* Stage 3 CC batch wire format. Multi-byte fields are network byte order. */
+#define OPENLI_CC_BATCH_MAGIC 0x4f4c4342U /* "OLCB" */
+#define OPENLI_CC_BATCH_VERSION 1U
+#define OPENLI_CC_BATCH_MAX_RECORDS 2048U
+#define OPENLI_CC_BATCH_MAX_BYTES (2U * 1024U * 1024U)
+
+/* A batch must always be able to carry at least one maximum-sized record.
+ * Record lengths are uint16_t, and each record has a two-byte length field
+ * after the eight-byte batch header. This also covers an MTU-sized packet
+ * plus ETSI encapsulation overhead with substantial margin. */
+_Static_assert(OPENLI_RAWIP_BATCH_MAX_BYTES >= 8U + 2U + UINT16_MAX,
+        "RAWIP batch byte limit cannot hold one maximum-sized record");
+_Static_assert(OPENLI_CC_BATCH_MAX_BYTES >= 8U + 2U + UINT16_MAX,
+        "CC batch byte limit cannot hold one maximum-sized record");
+
+typedef struct openli_cc_batch_record {
+    const uint8_t *body;
+    uint16_t len;
+} openli_cc_batch_record_t;
+
 /** Creates a connection to the internal RMQ instance for the purposes of
  *  writing intercept records received from a collector
  *
@@ -245,6 +276,18 @@ int publish_cc_on_mediator_liid_RMQ_queue(amqp_connection_state_t state,
 int publish_rawip_on_mediator_liid_RMQ_queue(amqp_connection_state_t state,
         uint8_t *msg, uint16_t msglen, char *liid, const char *queuename,
         uint8_t *is_blocked);
+
+/** Publishes multiple raw IP records as one versioned AMQP message. */
+int publish_rawip_batch_on_mediator_liid_RMQ_queue(
+        amqp_connection_state_t state,
+        const openli_rawip_batch_record_t *records, uint16_t record_count,
+        char *liid, const char *queuename, uint8_t *is_blocked);
+
+/** Publishes multiple encoded CC records as one versioned AMQP message. */
+int publish_cc_batch_on_mediator_liid_RMQ_queue(
+        amqp_connection_state_t state,
+        const openli_cc_batch_record_t *records, uint16_t record_count,
+        char *liid, const char *queuename, uint8_t *is_blocked);
 
 /** Consumes CC records using an RMQ connection, writing them into the
  *  provided export buffer.

--- a/src/mediator/pcapthread.c
+++ b/src/mediator/pcapthread.c
@@ -30,6 +30,19 @@
 #include "lea_send_thread.h"
 #include "util.h"
 #include "pcapthread.h"
+
+/*
+ * Performance tuning for the local PCAP output path.
+ *
+ * Previously the thread consumed at most 512 messages after every 50 ms
+ * timer tick, imposing an effective ceiling of about 10,240 packets/s.
+ * Drain several larger batches while keeping a time budget so control,
+ * rotation and shutdown events cannot be starved by a busy RAWIP queue.
+ */
+#define PCAP_RMQ_BATCH_SIZE 4096
+#define PCAP_DRAIN_BUDGET_NS (UINT64_C(20) * 1000 * 1000)
+#define PCAP_IDLE_POLL_MS 50
+
 #include "mediator_rmq.h"
 #include <libtrace.h>
 #include <assert.h>
@@ -565,31 +578,43 @@ static int write_pcap_from_buffered_rmq(handover_t *ho,
     uint32_t advance = 0;
     static int tally = 0;
 
-    bufrem = get_buffered_amount(&(ho->ho_state->buf));
-    while ((nextrec = get_buffered_head(&(ho->ho_state->buf), &bufrem))) {
-        /* TODO consider limiting the number of records written, so we
-         * don't get stuck in here for a long time?
-         */
+    uint64_t total_advance = 0;
+
+    nextrec = get_buffered_head(&(ho->ho_state->buf), &bufrem);
+    while (nextrec != NULL && bufrem > 0) {
         tally ++;
         if (ho->handover_type == HANDOVER_HI3) {
-            if ((advance = write_etsicc_to_pcap(nextrec, bufrem, pstate))
-                    == 0) {
-                return -1;
-            }
+            advance = write_etsicc_to_pcap(nextrec, bufrem, pstate);
         } else if (ho->handover_type == HANDOVER_HI2) {
             /* TODO */
             assert(0);
+            advance = 0;
         } else if (ho->handover_type == HANDOVER_RAWIP) {
-            if ((advance = write_rawip_to_pcap(nextrec, bufrem, pstate))
-                    == 0) {
-                return -1;
-            }
+            advance = write_rawip_to_pcap(nextrec, bufrem, pstate);
         } else {
             logger(LOG_INFO, "OpenLI Mediator: handover is corrupted in pcap thread");
+            advance = 0;
+        }
+
+        if (advance == 0 || advance > bufrem) {
+            /* Preserve progress already made in this batch. Otherwise a
+             * later retry would write those packets to the PCAP twice. */
+            if (total_advance > 0) {
+                advance_export_buffer_head(&(ho->ho_state->buf),
+                        total_advance);
+            }
             return -1;
         }
 
-        advance_export_buffer_head(&(ho->ho_state->buf), advance);
+        nextrec += advance;
+        bufrem -= advance;
+        total_advance += advance;
+    }
+
+    /* Updating the export buffer once per batch avoids running
+     * post_transmit() for every individual packet. */
+    if (total_advance > 0) {
+        advance_export_buffer_head(&(ho->ho_state->buf), total_advance);
     }
 
     if (!ho->ho_state->valid_rmq_ack) {
@@ -642,7 +667,8 @@ static int consume_pcap_packets(handover_t *ho, pcap_thread_state_t *pstate) {
                 &(ho->ho_state->buf), 1024, &(ho->ho_state->next_rmq_ack));
     } else if (ho->handover_type == HANDOVER_RAWIP) {
         r = consume_mediator_rawip_messages(ho->rmq_consumer,
-                &(ho->ho_state->buf), 512, &(ho->ho_state->next_rmq_ack));
+                &(ho->ho_state->buf), PCAP_RMQ_BATCH_SIZE,
+                &(ho->ho_state->next_rmq_ack));
     } else if (ho->handover_type == HANDOVER_HI2) {
         r = consume_mediator_iri_messages(ho->rmq_consumer,
                 &(ho->ho_state->buf), 1024, &(ho->ho_state->next_rmq_ack));
@@ -664,8 +690,12 @@ static int consume_pcap_packets(handover_t *ho, pcap_thread_state_t *pstate) {
         return 0;
     } else if (r == -1) {
         /* pcap writing error */
+        return -1;
     }
-    return r;
+
+    /* Signal that a batch was consumed. The caller may drain another batch
+     * immediately if its fairness budget has not expired. */
+    return 1;
 
 }
 
@@ -985,6 +1015,16 @@ static int pcap_thread_epoll_event(lea_thread_state_t *state,
  *
  *  @return NULL when the thread exits (via pthread_join())
  */
+static inline uint64_t monotonic_now_ns(void) {
+    struct timespec ts;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+        return 0;
+    }
+    return ((uint64_t)ts.tv_sec * UINT64_C(1000000000)) +
+            (uint64_t)ts.tv_nsec;
+}
+
 static void *run_pcap_thread(void *params) {
     lea_thread_state_t *state = (lea_thread_state_t *)params;
     openli_epoll_ev_t *flushtimer = NULL;
@@ -994,6 +1034,9 @@ static void *run_pcap_thread(void *params) {
     pcap_thread_state_t pstate;
     uint32_t firstflush;
     struct timeval tv;
+    uint64_t drain_started;
+    uint64_t drain_now;
+    int drain_result;
 
     // defined in lea_send_thread.c
     read_parent_config(state);
@@ -1042,7 +1085,7 @@ static void *run_pcap_thread(void *params) {
         }
 
         /* epoll */
-        if (start_openli_ms_timer(state->timerev, 50) < 0) {
+        if (start_openli_ms_timer(state->timerev, PCAP_IDLE_POLL_MS) < 0) {
             logger(LOG_INFO,"OpenLI Mediator: failed to add timer to epoll in agency thread for %s", state->agencyid);
             break;
         }
@@ -1075,8 +1118,22 @@ static void *run_pcap_thread(void *params) {
         /* Consume available packets and write them to their corresponding
          * pcap files */
 
-        /* TODO error handling? */
-        consume_pcap_packets(pstate.rawip_handover, &pstate);
+        /* Drain multiple batches after one wake-up. A monotonic time budget
+         * keeps the thread responsive to control, rotation and halt events. */
+        drain_started = monotonic_now_ns();
+        do {
+            drain_result = consume_pcap_packets(pstate.rawip_handover,
+                    &pstate);
+            if (drain_result <= 0) {
+                break;
+            }
+
+            drain_now = monotonic_now_ns();
+            if (drain_started != 0 && drain_now != 0 &&
+                    drain_now - drain_started >= PCAP_DRAIN_BUDGET_NS) {
+                break;
+            }
+        } while (1);
 
         halt_openli_timer(state->timerev);
     }


### PR DESCRIPTION
Publishing one AMQP message per intercepted record creates significant overhead
under high traffic. This change introduces per-LIID batching for CC and RAWIP
records sent through mediator RabbitMQ queues, substantially reducing both
publication and consumption overhead.

Key changes:
- Batch records per LIID up to 1024 records or a 2 MiB encoded body limit.
- Publish partial batches at the end of each receive pass, avoiding latency on low-volume streams.
- Add batch encoding/decoding on the RabbitMQ path and update LEA and PCAP consumers to process batched records.
- Correct publisher-confirm handling for shared delivery tags and non-monotonic tag orders in saved-record arrays.
- Support both individual and cumulative RabbitMQ ACKs and NACKs.
- Prevent consumer busy-looping using a short idle timeout while keeping active queue processing non-blocking.

Performance testing:
- **Single interception:** Throughput improved by nearly an order of magnitude, jumping from ~100 Mbit/s to ~1 Gbit/s.
- **Batch profile:** Active CC traffic yielded average batches of 948–972 records (1.14–1.17 MB), peaking at the 1024-record cap with zero RabbitMQ publication errors.
- **Thread capacity:** Two simultaneous interceptions reached ~1.4 Gbit/s when sharing a single collector forwarding thread. 
- *Note on scaling:* Full 2x 1 Gbit/s concurrency requires thread-load balancing on the collector side, which will be submitted in a separate PR.

Note: Code analyzed and prepared with assistance from GPT-5.6. Reviewed and tested manually.