### PR TITLE
Add a 'tlsgroups' option for restricting TLS key exchange

### DIFF
--- a/createCertsPQC
+++ b/createCertsPQC
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Copyright (C) 2025  Telefónica Innovación Digital (laura.dominguez.cespedes@telefonica.com)
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Creates a set of self-signed test certificates that use ML-DSA-87 (FIPS 204)
+# for signatures, as an alternative to the RSA certificates produced by
+# ./createCerts. Requires OpenSSL 3.5 or later.
+#
+# These are for testing only -- see doc/TLSDoc.md before using post-quantum
+# certificates in a real deployment.
+
+set -e
+
+if ! openssl list -signature-algorithms | grep -qi 'ML-DSA-87'; then
+    echo "error: this OpenSSL build does not provide ML-DSA-87." >&2
+    echo "ML-DSA requires OpenSSL 3.5 or later; you have:" >&2
+    openssl version >&2
+    exit 1
+fi
+
+# ML-DSA is a "pure" signature algorithm -- it does its own hashing, so unlike
+# createCerts we must not pass a -sha256 style digest option to any of these.
+
+openssl req -x509 -new -newkey ML-DSA-87 -noenc --subj /CN=OpenLItestCA -days 3650 -keyout ca-key.pem -out ca-crt.pem
+
+openssl genpkey -algorithm ML-DSA-87 -out provisioner-key.pem
+openssl req -new -subj /CN=provisioner -key provisioner-key.pem -out provisioner-csr.pem
+openssl x509 -req -days 365 -in provisioner-csr.pem -CA ca-crt.pem -CAkey ca-key.pem -CAcreateserial -out provisioner-crt.pem
+
+openssl genpkey -algorithm ML-DSA-87 -out mediator-key.pem
+openssl req -new -subj /CN=mediator -key mediator-key.pem -out mediator-csr.pem
+openssl x509 -req -days 365 -in mediator-csr.pem -CA ca-crt.pem -CAkey ca-key.pem -CAcreateserial -out mediator-crt.pem
+
+openssl genpkey -algorithm ML-DSA-87 -out collector-key.pem
+openssl req -new -subj /CN=collector -key collector-key.pem -out collector-csr.pem
+openssl x509 -req -days 365 -in collector-csr.pem -CA ca-crt.pem -CAkey ca-key.pem -CAcreateserial -out collector-crt.pem
+
+#creates mediator-crt.pem  mediator-csr.pem  mediator-key.pem  provisioner-crt.pem  provisioner-csr.pem  provisioner-key.pem  ca-crt.pem  ca-key.pem

--- a/doc/TLSDoc.md
+++ b/doc/TLSDoc.md
@@ -87,6 +87,91 @@ have created an `openli` user to run the provisioner component:
     chmod 400 /etc/openli/openli-provisioner-crt.pem
 
 
+## Post-quantum cryptography
+
+OpenSSL 3.5 (an LTS release, supported until 2030) added support for the
+NIST post-quantum standards to its default provider: ML-KEM (FIPS 203) for
+key exchange and ML-DSA (FIPS 204) for signatures. If you are running
+OpenSSL 3.5 or later, you can use these to protect OpenLI's internal
+communications against "harvest now, decrypt later" attacks, where an
+adversary records your traffic today and decrypts it once a
+cryptographically relevant quantum computer exists.
+
+You do not need liboqs, the OQS provider, or any special build of OpenLI to
+do this -- everything below uses stock OpenSSL. Check what you have with:
+
+    openssl version
+
+### Post-quantum key exchange
+
+This is the part that matters most for harvest-now-decrypt-later, and on
+OpenSSL 3.5 or later you get it for free: `X25519MLKEM768` is in OpenSSL's
+default group list, so an OpenLI deployment where both ends run OpenSSL 3.5+
+will already negotiate a post-quantum hybrid key exchange without any
+configuration at all.
+
+The default list also still includes classical groups, though, so a peer
+that does not offer ML-KEM will quietly fall back to X25519. If you would
+rather refuse such a connection than downgrade it, use the `tlsgroups`
+option to name the only groups you are willing to accept:
+
+    tlsgroups: X25519MLKEM768:SecP384r1MLKEM1024
+
+`tlsgroups` takes an OpenSSL group list -- a `:` separated list of group
+names in order of preference. Useful post-quantum names are
+`X25519MLKEM768`, `SecP256r1MLKEM768` and `SecP384r1MLKEM1024` (each a
+hybrid of ML-KEM with a classical curve, so the result is no weaker than
+the classical curve alone even if ML-KEM is later broken), plus the pure
+`MLKEM512`, `MLKEM768` and `MLKEM1024`. Hybrids are the conservative choice
+and are what we would suggest.
+
+Although it is described here in post-quantum terms, `tlsgroups` is a
+general option: it accepts any group list your OpenSSL release
+understands, including classical-only lists such as `X25519:P-384`, and
+the option itself works on OpenSSL releases much older than 3.5 -- it is
+only the post-quantum group names that need 3.5.
+
+A handshake succeeds as long as both ends have at least one group in
+common, so you do not have to roll this out everywhere at once. A
+component restricted to `X25519MLKEM768` will still talk to a peer that
+has no `tlsgroups` set at all, because OpenSSL 3.5's defaults include that
+group -- so you can enable it one component at a time.
+
+What will fail is a peer that offers no group you accept: one restricted
+to a classical-only list, or one running an OpenSSL older than 3.5, which
+has no ML-KEM to offer. That is the point of the option -- such a peer is
+refused rather than silently downgraded -- but it does mean you should
+upgrade every component to OpenSSL 3.5 before you start restricting
+groups anywhere.
+
+If OpenSSL does not recognise a name in the list -- most likely because
+you are on a release older than 3.5 -- OpenLI will log an error and fail
+to build an SSL context, so check the logs after changing this option.
+Leaving `tlsgroups` unset keeps OpenSSL's defaults, which is the right
+choice for most people.
+
+### Post-quantum certificates
+
+Key exchange protects the confidentiality of traffic recorded today.
+Certificates are a separate question: they authenticate the components to
+each other at the time of the handshake, so a quantum attacker cannot use a
+future capability to retrospectively forge a signature on a handshake that
+has already happened. Migrating them is therefore much less urgent than
+migrating key exchange, and you may reasonably choose to leave your RSA
+certificates alone for now.
+
+If you do want ML-DSA certificates, `./createCertsPQC` in the source tree
+generates a self-signed test set in the same way `createCerts` does, but
+using ML-DSA-87 instead of RSA. It requires OpenSSL 3.5 or later. The
+resulting certificates are used exactly like the RSA ones -- point
+`tlscert`, `tlskey` and `tlsca` at them as normal.
+
+Be aware that ML-DSA certificates are considerably larger than their RSA
+equivalents (roughly 10KB against roughly 2KB), which makes the handshake
+correspondingly bigger. Every component in the deployment needs to be
+running OpenSSL 3.5+ before you switch, since older versions cannot verify
+an ML-DSA signature at all.
+
 # Configuring OpenLI components to use the certificates
 
 You can enable internal TLS encryption by adding the following three options
@@ -96,6 +181,8 @@ to your configuration file for each component:
  * `tlskey`:  the location of the component's key file
  * `tlsca`: the location of the certificate file for the CA that signed the
           certificates (i.e. openli-ca-crt.pem).
+ * `tlsgroups`: optional -- restricts TLS key exchange to a specific list of
+          groups. See the post-quantum cryptography section above.
 
 If these config options are present and the certificates are successfully
 read on start-up, OpenLI will use TLS to encrypt all inter-component

--- a/doc/exampleconfigs/collector-example.yaml
+++ b/doc/exampleconfigs/collector-example.yaml
@@ -105,6 +105,11 @@ logstatfrequency: 5
 #tlskey: /etc/openli/openli-collector-key.pem
 #tlsca: /etc/openli/openli-ca-crt.pem
 
+# Restricts TLS key exchange to the groups listed here, in order of
+# preference. Peers must have at least one group in common to connect.
+# Leave commented out to use OpenSSL's defaults. See doc/TLSDoc.md.
+#tlsgroups: X25519MLKEM768:SecP384r1MLKEM1024
+
 # If set to 'no', intercepted packets streamed by this collector to the
 # mediator will not be encrypted -- this may be desirable for performance
 # reasons. Make sure you set the corresponding option on the mediator as

--- a/doc/exampleconfigs/mediator-example.yaml
+++ b/doc/exampleconfigs/mediator-example.yaml
@@ -64,6 +64,11 @@ pcapcompress: 1
 #tlskey: /etc/openli/openli-mediator-key.pem
 #tlsca: /etc/openli/openli-ca-crt.pem
 
+# Restricts TLS key exchange to the groups listed here, in order of
+# preference. Peers must have at least one group in common to connect.
+# Leave commented out to use OpenSSL's defaults. See doc/TLSDoc.md.
+#tlsgroups: X25519MLKEM768:SecP384r1MLKEM1024
+
 # To receive records from collectors that are using RabbitMQ to persist
 # unacknowledged data, you will need to provide the credentials necessary
 # for the mediator to authenticate against the RabbitMQ server running on the

--- a/doc/exampleconfigs/provisioner-example.yaml
+++ b/doc/exampleconfigs/provisioner-example.yaml
@@ -23,6 +23,11 @@ updateport: 9009
 #tlskey: /etc/openli/openli-provisioner-key.pem
 #tlsca: /etc/openli/openli-ca-crt.pem
 
+# Restricts TLS key exchange to the groups listed here, in order of
+# preference. Peers must have at least one group in common to connect.
+# Leave commented out to use OpenSSL's defaults. See doc/TLSDoc.md.
+#tlsgroups: X25519MLKEM768:SecP384r1MLKEM1024
+
 # Current intercept configuration will be stored in the following file.
 # Make sure that this file is writable by the OpenLI provisioner!
 intercept-config-file: /etc/openli/running-intercept-config.yaml

--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -2321,6 +2321,7 @@ static void init_collector_global(collector_global_t *glob) {
     glob->sslconf.keyfile = NULL;
     glob->sslconf.cacertfile = NULL;
     glob->sslconf.logkeyfile = NULL;
+    glob->sslconf.tlsgroups = NULL;
     glob->sslconf.ctx = NULL;
 
     glob->RMQ_conf.name = NULL;

--- a/src/collector/configparser_collector.c
+++ b/src/collector/configparser_collector.c
@@ -646,6 +646,13 @@ static int collector_parser(void *arg, yaml_document_t *doc,
 
     if (key->type == YAML_SCALAR_NODE &&
             value->type == YAML_SCALAR_NODE &&
+            strcasecmp((char *)key->data.scalar.value, "tlsgroups") == 0) {
+        SET_CONFIG_STRING_OPTION(glob->sslconf.tlsgroups, value);
+        return 0;
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
             strcasecmp((char *)key->data.scalar.value, "tlskeylogfile") == 0) {
         SET_CONFIG_STRING_OPTION(glob->sslconf.logkeyfile, value);
         return 0;

--- a/src/collector/configwriter_collector.c
+++ b/src/collector/configwriter_collector.c
@@ -294,6 +294,7 @@ static int emit_basic_collector_options(collector_global_t *conf,
     YAML_EMIT_STRING(event, "tlscert", conf->sslconf.certfile);
     YAML_EMIT_STRING(event, "tlskey", conf->sslconf.keyfile);
     YAML_EMIT_STRING(event, "tlsca", conf->sslconf.cacertfile);
+    YAML_EMIT_STRING(event, "tlsgroups", conf->sslconf.tlsgroups);
     YAML_EMIT_STRING(event, "tlskeylogfile", conf->sslconf.logkeyfile);
 
     YAML_EMIT_BOOLEAN(event, "sipignoresdpo",

--- a/src/mediator/configparser_mediator.c
+++ b/src/mediator/configparser_mediator.c
@@ -157,6 +157,12 @@ static int mediator_parser(void *arg, yaml_document_t *doc UNUSED,
 
     if (key->type == YAML_SCALAR_NODE &&
             value->type == YAML_SCALAR_NODE &&
+            strcasecmp(keyname, "tlsgroups") == 0) {
+        SET_CONFIG_STRING_OPTION(state->sslconf.tlsgroups, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
             strcasecmp(keyname, "etsitls") == 0) {
             state->etsitls = config_check_onoff((char *)value->data.scalar.value);
     }

--- a/src/mediator/mediator.c
+++ b/src/mediator/mediator.c
@@ -207,6 +207,7 @@ static int init_mediator_config(mediator_state_t *state,
     state->sslconf.keyfile = NULL;
     state->sslconf.cacertfile = NULL;
     state->sslconf.logkeyfile = NULL;
+    state->sslconf.tlsgroups = NULL;
     state->sslconf.ctx = NULL;
 
     state->RMQ_conf.name = NULL;

--- a/src/openli_tls.c
+++ b/src/openli_tls.c
@@ -95,6 +95,18 @@ static SSL_CTX * ssl_init(openli_ssl_config_t *sslconf) {
     /* Enforce use of TLSv1_3 */
     SSL_CTX_set_min_proto_version(ctx, TLS1_3_VERSION);
 
+    if (sslconf->tlsgroups) {
+        if (SSL_CTX_set1_groups_list(ctx, sslconf->tlsgroups) != 1) {
+            logger(LOG_INFO, "OpenLI: unable to set TLS key exchange groups to {%s}",
+                    sslconf->tlsgroups);
+            logger(LOG_INFO, "OpenLI: check that your OpenSSL version supports every group in that list (post-quantum groups require OpenSSL 3.5 or later)");
+            SSL_CTX_free(ctx);
+            return NULL;
+        }
+        logger(LOG_DEBUG, "OpenLI: TLS key exchange groups restricted to %s",
+                sslconf->tlsgroups);
+    }
+
     if (SSL_CTX_load_verify_locations(ctx, sslconf->cacertfile,
                 "./") != 1){ //TODO this might want to be changed
         logger(LOG_INFO, "OpenLI: SSL CA cert loading {%s} failed",
@@ -197,6 +209,11 @@ void free_ssl_config(openli_ssl_config_t *sslconf) {
     if (sslconf->cacertfile) {
         free(sslconf->cacertfile);
         sslconf->cacertfile = NULL;
+    }
+
+    if (sslconf->tlsgroups) {
+        free(sslconf->tlsgroups);
+        sslconf->tlsgroups = NULL;
     }
 
     if (sslconf->ctx) {
@@ -312,6 +329,23 @@ int reload_ssl_config(openli_ssl_config_t *current,
         }
     }
 
+    if (current->tlsgroups == NULL && newconf->tlsgroups != NULL) {
+        current->tlsgroups = newconf->tlsgroups;
+        newconf->tlsgroups = NULL;
+        changestate = 1;
+    } else if (current->tlsgroups != NULL && newconf->tlsgroups == NULL) {
+        free(current->tlsgroups);
+        current->tlsgroups = NULL;
+        changestate = 1;
+    } else if (current->tlsgroups && newconf->tlsgroups) {
+        if (strcmp(current->tlsgroups, newconf->tlsgroups) != 0) {
+            free(current->tlsgroups);
+            current->tlsgroups = newconf->tlsgroups;
+            newconf->tlsgroups = NULL;
+            changestate = 1;
+        }
+    }
+
     if (!changestate) {
         logger(LOG_INFO, "OpenLI: TLS configuration is unchanged.");
         return 0;
@@ -327,7 +361,7 @@ int reload_ssl_config(openli_ssl_config_t *current,
     return 1;
 }
 
-#define PEM_READ_SIZE 1024
+#define PEM_READ_SIZE 16384
 
 int load_pem_into_memory(char *pemfile, char **memspace) {
 

--- a/src/openli_tls.h
+++ b/src/openli_tls.h
@@ -44,6 +44,7 @@ typedef struct openli_ssl_config {
     char *cacertfile;
     char *certfile;
     char *logkeyfile;
+    char *tlsgroups;
     SSL_CTX *ctx;
 } openli_ssl_config_t;
 

--- a/src/provisioner/configparser_provisioner.c
+++ b/src/provisioner/configparser_provisioner.c
@@ -1578,6 +1578,12 @@ static int provisioning_parser(void *arg, yaml_document_t *doc UNUSED,
 
     if (key->type == YAML_SCALAR_NODE &&
             value->type == YAML_SCALAR_NODE &&
+            strcasecmp((char *)key->data.scalar.value, "tlsgroups") == 0) {
+        SET_CONFIG_STRING_OPTION(state->sslconf.tlsgroups, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SCALAR_NODE &&
             strcasecmp((char *)key->data.scalar.value, "restauthdb") == 0) {
         SET_CONFIG_STRING_OPTION(state->restauthdbfile, value);
     }

--- a/src/provisioner/provisioner.c
+++ b/src/provisioner/provisioner.c
@@ -312,6 +312,7 @@ int init_prov_state(provision_state_t *state, char *configfile,
     state->sslconf.keyfile = NULL;
     state->sslconf.cacertfile = NULL;
     state->sslconf.logkeyfile = NULL;
+    state->sslconf.tlsgroups = NULL;
     state->sslconf.ctx = NULL;
 
     state->key_pem = NULL;


### PR DESCRIPTION
OpenSSL 3.5 includes X25519MLKEM768 in its default group list, so an OpenLI deployment running 3.5 or later already negotiates a post-quantum hybrid key exchange on its internal links without any configuration at all. The default list still offers classical groups as well, though, so a peer that does not support ML-KEM will quietly fall back to X25519.

'tlsgroups' takes an OpenSSL group list and hands it to SSL_CTX_set1_groups_list(), which lets an operator require post-quantum key exchange rather than merely allow it. Leaving the option unset keeps OpenSSL's defaults, which is the right choice for most deployments.

 * add 'tlsgroups' to the provisioner, collector and mediator config parsers, and to the collector config writer so that the option survives a config rewrite.
 * apply the group list in 'ssl_init()', which now fails if OpenSSL does not recognise one of the names -- the post-quantum groups require OpenSSL 3.5 or later.
 * handle 'tlsgroups' in 'free_ssl_config()' and 'reload_ssl_config()'.
 * increase PEM_READ_SIZE to 16384; ML-DSA certificates are roughly 10KB against roughly 2KB for their RSA equivalents.
 * add createCertsPQC, which generates a self-signed ML-DSA-87 test set in the same way that createCerts does for RSA. Requires OpenSSL 3.5.
 * document the above in doc/TLSDoc.md.

createCertsPQC is derived from the script contributed by @laaurii00 in PR #105.