### PR TITLE
Feature/ipcc prefix filter

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -58,6 +58,8 @@ openlicollector_SOURCES=collector/collector.c \
 		collector/ipmmiri.h \
                 collector/internetaccess.c collector/internetaccess.h \
 		collector/ipcc.c collector/ipcc.h \
+		collector/cc_prefix_filter.c \
+		collector/cc_prefix_filter.h \
                 coreserver.h coreserver.c collector/collector_push_messaging.c \
                 collector/collector_push_messaging.h \
 		collector/alushim_parser.c collector/alushim_parser.h \

--- a/src/collector/alushim_parser.c
+++ b/src/collector/alushim_parser.c
@@ -162,6 +162,7 @@ int check_alu_intercept(colthread_local_t *loc,
     vendmirror_intercept_t *alu, *tmp;
     vendmirror_intercept_list_t *vmilist;
     uint32_t rem = 0, shimintid, cin, bodylen;
+    uint64_t packet_mask;
     void *l3;
     uint8_t *payload = NULL;
     uint8_t direction;
@@ -192,6 +193,9 @@ int check_alu_intercept(colthread_local_t *loc,
         return 0;
     }
 
+    packet_mask = openli_cc_prefix_filter_match_l3(
+            loc->ipcc_prefix_filter, l3, bodylen);
+
     /* Direction 0 = ingress (i.e. coming from the subscriber) */
 
     /* Use the session ID from the shim as the CIN */
@@ -203,6 +207,11 @@ int check_alu_intercept(colthread_local_t *loc,
         }
         if (alu->common.toend_time > 0 &&
                 alu->common.toend_time < pinfo->tv.tv_sec) {
+            continue;
+        }
+
+        if (packet_mask != 0 &&
+                (packet_mask & alu->cc_exclude_mask) != 0) {
             continue;
         }
 

--- a/src/collector/cc_prefix_filter.c
+++ b/src/collector/cc_prefix_filter.c
@@ -309,6 +309,51 @@ uint64_t openli_cc_prefix_filter_match(
     return node_group_mask(node);
 }
 
+uint64_t openli_cc_prefix_filter_match_l3(
+        const openli_cc_prefix_filter_t *filter, const void *l3,
+        uint32_t l3len) {
+    const uint8_t *packet = (const uint8_t *)l3;
+    const void *src;
+    const void *dst;
+    uint64_t mask;
+    uint8_t version;
+
+    if (filter == NULL || packet == NULL || l3len == 0) {
+        return 0;
+    }
+
+    version = packet[0] >> 4;
+    if (version == 4) {
+        uint8_t ihl;
+
+        if (l3len < 20) {
+            return 0;
+        }
+        ihl = (packet[0] & 0x0f) * 4;
+        if (ihl < 20 || l3len < ihl) {
+            return 0;
+        }
+        src = packet + 12;
+        dst = packet + 16;
+        mask = openli_cc_prefix_filter_match(filter, AF_INET, src);
+        mask |= openli_cc_prefix_filter_match(filter, AF_INET, dst);
+        return mask;
+    }
+
+    if (version == 6) {
+        if (l3len < 40) {
+            return 0;
+        }
+        src = packet + 8;
+        dst = packet + 24;
+        mask = openli_cc_prefix_filter_match(filter, AF_INET6, src);
+        mask |= openli_cc_prefix_filter_match(filter, AF_INET6, dst);
+        return mask;
+    }
+
+    return 0;
+}
+
 size_t openli_cc_prefix_filter_count(
         const openli_cc_prefix_filter_t *filter, int family) {
     if (filter == NULL) {

--- a/src/collector/cc_prefix_filter.c
+++ b/src/collector/cc_prefix_filter.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026 Pawel Jablonski
+ *
+ * This file is part of OpenLI.
+ *
+ * OpenLI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ */
+
+#include "cc_prefix_filter.h"
+
+#include <arpa/inet.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "patricia.h"
+
+struct openli_cc_prefix_filter {
+    patricia_tree_t *ipv4;
+    patricia_tree_t *ipv6;
+    size_t ipv4_count;
+    size_t ipv6_count;
+    int finalised;
+};
+
+static int family_parameters(int family, uint8_t *maximum_bits,
+        size_t *address_length) {
+    if (family == AF_INET) {
+        *maximum_bits = 32;
+        *address_length = sizeof(struct in_addr);
+        return 0;
+    }
+
+    if (family == AF_INET6) {
+        *maximum_bits = 128;
+        *address_length = sizeof(struct in6_addr);
+        return 0;
+    }
+
+    return -1;
+}
+
+static patricia_tree_t *tree_for_family(
+        const openli_cc_prefix_filter_t *filter, int family) {
+    if (family == AF_INET) {
+        return filter->ipv4;
+    }
+    if (family == AF_INET6) {
+        return filter->ipv6;
+    }
+    return NULL;
+}
+
+static size_t *count_for_family(openli_cc_prefix_filter_t *filter,
+        int family) {
+    if (family == AF_INET) {
+        return &filter->ipv4_count;
+    }
+    if (family == AF_INET6) {
+        return &filter->ipv6_count;
+    }
+    return NULL;
+}
+
+static void initialise_prefix(prefix_t *prefix, int family,
+        const void *address, uint8_t prefix_length) {
+    memset(prefix, 0, sizeof(*prefix));
+    prefix->family = (u_short)family;
+    prefix->bitlen = prefix_length;
+
+    if (family == AF_INET) {
+        memcpy(&prefix->add.sin, address, sizeof(prefix->add.sin));
+    } else {
+        memcpy(&prefix->add.sin6, address, sizeof(prefix->add.sin6));
+    }
+}
+
+static void clear_host_bits(void *address, size_t address_length,
+        uint8_t prefix_length) {
+    uint8_t *bytes = address;
+    size_t whole_bytes = prefix_length / 8;
+    uint8_t remaining_bits = prefix_length % 8;
+    size_t first_host_byte;
+
+    if (remaining_bits != 0) {
+        bytes[whole_bytes] &= (uint8_t)(0xffU << (8 - remaining_bits));
+        first_host_byte = whole_bytes + 1;
+    } else {
+        first_host_byte = whole_bytes;
+    }
+
+    if (first_host_byte < address_length) {
+        memset(bytes + first_host_byte, 0,
+                address_length - first_host_byte);
+    }
+}
+
+static int prefix_bits_equal(const prefix_t *left, const prefix_t *right,
+        uint8_t bits) {
+    const uint8_t *left_bytes = prefix_touchar(left);
+    const uint8_t *right_bytes = prefix_touchar(right);
+    size_t whole_bytes = bits / 8;
+    uint8_t remaining_bits = bits % 8;
+    uint8_t mask;
+
+    if (whole_bytes > 0 &&
+            memcmp(left_bytes, right_bytes, whole_bytes) != 0) {
+        return 0;
+    }
+
+    if (remaining_bits == 0) {
+        return 1;
+    }
+
+    mask = (uint8_t)(0xffU << (8 - remaining_bits));
+    return (left_bytes[whole_bytes] & mask) ==
+            (right_bytes[whole_bytes] & mask);
+}
+
+static int prefixes_overlap(const prefix_t *left, const prefix_t *right) {
+    uint8_t comparison_bits;
+
+    if (left->family != right->family) {
+        return 0;
+    }
+
+    comparison_bits = left->bitlen < right->bitlen ?
+            left->bitlen : right->bitlen;
+    return prefix_bits_equal(left, right, comparison_bits);
+}
+
+static uint64_t node_group_mask(const patricia_node_t *node) {
+    const uint64_t *mask;
+
+    if (node == NULL || node->data == NULL) {
+        return 0;
+    }
+
+    mask = PATRICIA_DATA_GET(node, uint64_t);
+    return *mask;
+}
+
+static openli_cc_prefix_filter_result_t check_existing_prefixes(
+        patricia_tree_t *tree, const prefix_t *candidate,
+        uint64_t group_mask) {
+    patricia_node_t *node;
+
+    PATRICIA_WALK(tree->head, node) {
+        uint64_t existing_mask;
+
+        if (prefixes_overlap(node->prefix, candidate)) {
+            existing_mask = node_group_mask(node);
+            if (node->prefix->bitlen == candidate->bitlen &&
+                    prefix_bits_equal(node->prefix, candidate,
+                            candidate->bitlen) &&
+                    existing_mask == group_mask) {
+                return OPENLI_CC_PREFIX_FILTER_DUPLICATE;
+            }
+
+            if (existing_mask != group_mask) {
+                return OPENLI_CC_PREFIX_FILTER_OVERLAP;
+            }
+        }
+    } PATRICIA_WALK_END;
+
+    return OPENLI_CC_PREFIX_FILTER_OK;
+}
+
+openli_cc_prefix_filter_t *openli_cc_prefix_filter_create(void) {
+    openli_cc_prefix_filter_t *filter;
+
+    filter = calloc(1, sizeof(*filter));
+    if (filter == NULL) {
+        return NULL;
+    }
+
+    filter->ipv4 = New_Patricia(32);
+    if (filter->ipv4 == NULL) {
+        free(filter);
+        return NULL;
+    }
+
+    filter->ipv6 = New_Patricia(128);
+    if (filter->ipv6 == NULL) {
+        Destroy_Patricia(filter->ipv4, free);
+        free(filter);
+        return NULL;
+    }
+
+    return filter;
+}
+
+void openli_cc_prefix_filter_destroy(openli_cc_prefix_filter_t *filter) {
+    if (filter == NULL) {
+        return;
+    }
+
+    Destroy_Patricia(filter->ipv4, free);
+    Destroy_Patricia(filter->ipv6, free);
+    free(filter);
+}
+
+openli_cc_prefix_filter_result_t openli_cc_prefix_filter_add(
+        openli_cc_prefix_filter_t *filter, int family, const void *address,
+        uint8_t prefix_length, uint8_t group_id) {
+    uint8_t normalised[sizeof(struct in6_addr)];
+    uint8_t maximum_bits;
+    size_t address_length;
+    size_t *prefix_count;
+    patricia_tree_t *tree;
+    patricia_node_t *node;
+    prefix_t prefix;
+    uint64_t group_mask;
+    uint64_t *stored_mask;
+    openli_cc_prefix_filter_result_t result;
+
+    if (filter == NULL || address == NULL ||
+            group_id >= OPENLI_CC_PREFIX_FILTER_MAX_GROUPS) {
+        return OPENLI_CC_PREFIX_FILTER_INVALID_ARGUMENT;
+    }
+
+    if (filter->finalised) {
+        return OPENLI_CC_PREFIX_FILTER_FINALISED;
+    }
+
+    if (family_parameters(family, &maximum_bits, &address_length) != 0 ||
+            prefix_length > maximum_bits) {
+        return OPENLI_CC_PREFIX_FILTER_INVALID_ARGUMENT;
+    }
+
+    memset(normalised, 0, sizeof(normalised));
+    memcpy(normalised, address, address_length);
+    clear_host_bits(normalised, address_length, prefix_length);
+    initialise_prefix(&prefix, family, normalised, prefix_length);
+
+    tree = tree_for_family(filter, family);
+    prefix_count = count_for_family(filter, family);
+    group_mask = UINT64_C(1) << group_id;
+
+    result = check_existing_prefixes(tree, &prefix, group_mask);
+    if (result != OPENLI_CC_PREFIX_FILTER_OK) {
+        return result;
+    }
+
+    stored_mask = malloc(sizeof(*stored_mask));
+    if (stored_mask == NULL) {
+        return OPENLI_CC_PREFIX_FILTER_NO_MEMORY;
+    }
+    *stored_mask = group_mask;
+
+    node = patricia_lookup(tree, &prefix);
+    if (node == NULL) {
+        free(stored_mask);
+        return OPENLI_CC_PREFIX_FILTER_NO_MEMORY;
+    }
+
+    if (node->data != NULL) {
+        free(stored_mask);
+        return OPENLI_CC_PREFIX_FILTER_DUPLICATE;
+    }
+
+    PATRICIA_DATA_SET(node, stored_mask);
+    (*prefix_count)++;
+    return OPENLI_CC_PREFIX_FILTER_OK;
+}
+
+openli_cc_prefix_filter_result_t openli_cc_prefix_filter_finalise(
+        openli_cc_prefix_filter_t *filter) {
+    if (filter == NULL) {
+        return OPENLI_CC_PREFIX_FILTER_INVALID_ARGUMENT;
+    }
+
+    filter->finalised = 1;
+    return OPENLI_CC_PREFIX_FILTER_OK;
+}
+
+uint64_t openli_cc_prefix_filter_match(
+        const openli_cc_prefix_filter_t *filter, int family,
+        const void *address) {
+    uint8_t maximum_bits;
+    size_t address_length;
+    patricia_tree_t *tree;
+    patricia_node_t *node;
+    prefix_t prefix;
+
+    if (filter == NULL || address == NULL || !filter->finalised) {
+        return 0;
+    }
+
+    if (family_parameters(family, &maximum_bits, &address_length) != 0) {
+        return 0;
+    }
+
+    tree = tree_for_family(filter, family);
+    if (tree == NULL) {
+        return 0;
+    }
+
+    if ((family == AF_INET && filter->ipv4_count == 0) ||
+            (family == AF_INET6 && filter->ipv6_count == 0)) {
+        return 0;
+    }
+
+    (void)address_length;
+    initialise_prefix(&prefix, family, address, maximum_bits);
+    node = patricia_search_best2(tree, &prefix, 1);
+    return node_group_mask(node);
+}
+
+size_t openli_cc_prefix_filter_count(
+        const openli_cc_prefix_filter_t *filter, int family) {
+    if (filter == NULL) {
+        return 0;
+    }
+
+    if (family == AF_INET) {
+        return filter->ipv4_count;
+    }
+    if (family == AF_INET6) {
+        return filter->ipv6_count;
+    }
+    return 0;
+}
+
+int openli_cc_prefix_filter_is_finalised(
+        const openli_cc_prefix_filter_t *filter) {
+    return filter != NULL && filter->finalised;
+}
+
+const char *openli_cc_prefix_filter_result_string(
+        openli_cc_prefix_filter_result_t result) {
+    switch (result) {
+        case OPENLI_CC_PREFIX_FILTER_OK:
+            return "success";
+        case OPENLI_CC_PREFIX_FILTER_DUPLICATE:
+            return "duplicate prefix";
+        case OPENLI_CC_PREFIX_FILTER_INVALID_ARGUMENT:
+            return "invalid argument";
+        case OPENLI_CC_PREFIX_FILTER_NO_MEMORY:
+            return "out of memory";
+        case OPENLI_CC_PREFIX_FILTER_OVERLAP:
+            return "prefix overlaps another group";
+        case OPENLI_CC_PREFIX_FILTER_FINALISED:
+            return "filter is already finalised";
+        default:
+            return "unknown prefix filter result";
+    }
+}

--- a/src/collector/cc_prefix_filter.h
+++ b/src/collector/cc_prefix_filter.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 Pawel Jablonski
+ *
+ * This file is part of OpenLI.
+ *
+ * OpenLI is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ */
+
+#ifndef OPENLI_CC_PREFIX_FILTER_H_
+#define OPENLI_CC_PREFIX_FILTER_H_
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/socket.h>
+
+#define OPENLI_CC_PREFIX_FILTER_MAX_GROUPS 64
+
+typedef struct openli_cc_prefix_filter openli_cc_prefix_filter_t;
+
+typedef enum openli_cc_prefix_filter_result {
+    OPENLI_CC_PREFIX_FILTER_OK = 0,
+    OPENLI_CC_PREFIX_FILTER_DUPLICATE = 1,
+    OPENLI_CC_PREFIX_FILTER_INVALID_ARGUMENT = -1,
+    OPENLI_CC_PREFIX_FILTER_NO_MEMORY = -2,
+    OPENLI_CC_PREFIX_FILTER_OVERLAP = -3,
+    OPENLI_CC_PREFIX_FILTER_FINALISED = -4
+} openli_cc_prefix_filter_result_t;
+
+/*
+ * Allocate an empty prefix filter. Prefixes may be added until
+ * openli_cc_prefix_filter_finalise() is called.
+ */
+openli_cc_prefix_filter_t *openli_cc_prefix_filter_create(void);
+
+/*
+ * Destroy a filter. The filter must no longer be referenced by packet
+ * processing threads when this function is called.
+ */
+void openli_cc_prefix_filter_destroy(openli_cc_prefix_filter_t *filter);
+
+/*
+ * Add a binary IPv4 or IPv6 prefix to a filter group.
+ *
+ * family must be AF_INET or AF_INET6. address must point to struct in_addr
+ * or struct in6_addr respectively. group_id must be in the range 0..63.
+ * Host bits in address are cleared before the prefix is inserted.
+ *
+ * Prefixes belonging to different groups may not overlap. Re-adding the
+ * exact same prefix to the same group returns
+ * OPENLI_CC_PREFIX_FILTER_DUPLICATE.
+ */
+openli_cc_prefix_filter_result_t openli_cc_prefix_filter_add(
+        openli_cc_prefix_filter_t *filter, int family, const void *address,
+        uint8_t prefix_length, uint8_t group_id);
+
+/*
+ * Prevent further modifications to filter. After successful finalisation,
+ * concurrent lookups are safe because the Patricia tries are immutable.
+ */
+openli_cc_prefix_filter_result_t openli_cc_prefix_filter_finalise(
+        openli_cc_prefix_filter_t *filter);
+
+/*
+ * Return the group mask for the longest prefix matching address.
+ *
+ * A return value of zero means that no configured prefix matched. The
+ * filter must have been finalised before this function is called. Invalid
+ * arguments also return zero.
+ */
+uint64_t openli_cc_prefix_filter_match(
+        const openli_cc_prefix_filter_t *filter, int family,
+        const void *address);
+
+/* Return the number of configured prefixes for an address family. */
+size_t openli_cc_prefix_filter_count(
+        const openli_cc_prefix_filter_t *filter, int family);
+
+/* Return non-zero after the filter has been finalised. */
+int openli_cc_prefix_filter_is_finalised(
+        const openli_cc_prefix_filter_t *filter);
+
+const char *openli_cc_prefix_filter_result_string(
+        openli_cc_prefix_filter_result_t result);
+
+#endif

--- a/src/collector/cc_prefix_filter.h
+++ b/src/collector/cc_prefix_filter.h
@@ -74,6 +74,15 @@ uint64_t openli_cc_prefix_filter_match(
         const openli_cc_prefix_filter_t *filter, int family,
         const void *address);
 
+/*
+ * Safely extract source and destination addresses from an IPv4 or IPv6
+ * packet beginning at l3, and return the union of their matching group masks.
+ * Returns zero for NULL, truncated, malformed, or non-IP input.
+ */
+uint64_t openli_cc_prefix_filter_match_l3(
+        const openli_cc_prefix_filter_t *filter, const void *l3,
+        uint32_t l3len);
+
 /* Return the number of configured prefixes for an address family. */
 size_t openli_cc_prefix_filter_count(
         const openli_cc_prefix_filter_t *filter, int family);

--- a/src/collector/cisco_parser.c
+++ b/src/collector/cisco_parser.c
@@ -91,6 +91,7 @@ int generate_cc_from_cisco(colthread_local_t *loc,
     void *payload;
     uint8_t *l3;
     uint32_t rem, cept_id, bodylen;
+    uint64_t packet_mask;
     vendmirror_intercept_t *cept, *tmp;
     vendmirror_intercept_list_t *vmilist;
 
@@ -105,6 +106,9 @@ int generate_cc_from_cisco(colthread_local_t *loc,
         return 0;
     }
 
+    packet_mask = openli_cc_prefix_filter_match_l3(
+            loc->ipcc_prefix_filter, l3, bodylen);
+
     HASH_ITER(hh, vmilist->intercepts, cept, tmp) {
         if (pinfo->tv.tv_sec < cept->common.tostart_time) {
             continue;
@@ -113,6 +117,11 @@ int generate_cc_from_cisco(colthread_local_t *loc,
                 cept->common.toend_time < pinfo->tv.tv_sec) {
             continue;
         }
+        if (packet_mask != 0 &&
+                (packet_mask & cept->cc_exclude_mask) != 0) {
+            continue;
+        }
+
         /* Create an appropriate IPCC and export it */
         if (push_vendor_mirrored_ipcc_job(
                 loc->zmq_pubsocks[cept->common.seqtrackerid], &(cept->common),

--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -2167,6 +2167,18 @@ static void clear_global_config(collector_global_t *glob) {
         free_coreserver_list(glob->ciscomirrors);
     }
 
+    if (glob->ipcc_prefix_filter) {
+        openli_cc_prefix_filter_destroy(glob->ipcc_prefix_filter);
+        glob->ipcc_prefix_filter = NULL;
+    }
+    for (uint8_t i = 0; i < glob->ipcc_prefix_group_count; i++) {
+        free(glob->ipcc_prefix_group_names[i]);
+        glob->ipcc_prefix_group_names[i] = NULL;
+    }
+    glob->ipcc_prefix_group_count = 0;
+    free(glob->ipcc_prefix_config);
+    glob->ipcc_prefix_config = NULL;
+
     if (glob->RMQ_conf.name) {
         free(glob->RMQ_conf.name);
     }
@@ -2647,6 +2659,15 @@ static int reload_collector_config(collector_global_t *glob,
     if (create_ssl_context(&(newstate.sslconf)) < 0) {
         ret = -1;
         goto endreload;
+    }
+
+    if ((glob->ipcc_prefix_config == NULL) !=
+            (newstate.ipcc_prefix_config == NULL) ||
+            (glob->ipcc_prefix_config != NULL &&
+            strcmp(glob->ipcc_prefix_config,
+                    newstate.ipcc_prefix_config) != 0)) {
+        logger(LOG_INFO,
+                "OpenLI: IPCC prefix exclusion filter changes require a collector restart; retaining the active filter");
     }
 
     tlschanged = reload_ssl_config(&(glob->sslconf), &(newstate.sslconf));

--- a/src/collector/collector.c
+++ b/src/collector/collector.c
@@ -509,6 +509,7 @@ static void init_collocal(colthread_local_t *loc, collector_global_t *glob) {
     loc->staticv6ranges = New_Patricia(128);
     loc->dynamicv6ranges = New_Patricia(128);
     loc->staticcache = NULL;
+    loc->ipcc_prefix_filter = glob->ipcc_prefix_filter;
     loc->tosyncq_ip = NULL;
 
     loc->accepted = 0;

--- a/src/collector/collector.h
+++ b/src/collector/collector.h
@@ -49,6 +49,7 @@
 #include "reassembler.h"
 #include "collector_publish.h"
 #include "collector_base.h"
+#include "cc_prefix_filter.h"
 #include "openli_tls.h"
 #include "radius_hasher.h"
 #include "email_ingest_service.h"
@@ -368,6 +369,11 @@ struct collector_global {
     coreserver_t *alumirrors;
     coreserver_t *jmirrors;
     coreserver_t *ciscomirrors;
+
+    openli_cc_prefix_filter_t *ipcc_prefix_filter;
+    char *ipcc_prefix_group_names[OPENLI_CC_PREFIX_FILTER_MAX_GROUPS];
+    char *ipcc_prefix_config;
+    uint8_t ipcc_prefix_group_count;
 
     pthread_t seqproxy_tid;
 

--- a/src/collector/collector.h
+++ b/src/collector/collector.h
@@ -299,6 +299,8 @@ typedef struct colthread_local {
     patricia_tree_t *dynamicv6ranges;
     static_ipcache_t *staticcache;
 
+    const openli_cc_prefix_filter_t *ipcc_prefix_filter;
+
     ipfrag_reassembler_t *fragreass;
 
     uint64_t accepted;

--- a/src/collector/collector_push_messaging.c
+++ b/src/collector/collector_push_messaging.c
@@ -330,6 +330,7 @@ static int update_ipv4_intercept(colthread_local_t *loc, ipsession_t *toup) {
     }
 
     update_intercept_common(&(found->common), &(toup->common));
+    found->cc_exclude_mask = toup->cc_exclude_mask;
     return 1;
 }
 
@@ -399,6 +400,7 @@ static int update_ipv6_intercept(colthread_local_t *loc, ipsession_t *toup) {
     }
 
     update_intercept_common(&(found->common), &(toup->common));
+    found->cc_exclude_mask = toup->cc_exclude_mask;
     return 1;
 }
 
@@ -824,6 +826,7 @@ void handle_change_iprange_intercept(colthread_local_t *loc,
             sessrec);
     if (sessrec) {
         update_intercept_common(&(sessrec->common), &(ipr->common));
+        sessrec->cc_exclude_mask = ipr->cc_exclude_mask;
     }
 
     free_single_staticipsession(ipr);

--- a/src/collector/collector_push_messaging.c
+++ b/src/collector/collector_push_messaging.c
@@ -814,6 +814,7 @@ void handle_change_vendmirror_intercept(colthread_local_t *loc,
     }
 
     update_intercept_common(&(found->common), &(vend->common));
+    found->cc_exclude_mask = vend->cc_exclude_mask;
     free_single_vendmirror_intercept(vend);
 }
 

--- a/src/collector/collector_sync.c
+++ b/src/collector/collector_sync.c
@@ -51,6 +51,11 @@
 #include "collector_util.h"
 #include "collector_integrity_check.h"
 
+static int resolve_ipintercept_cc_exclude_mask(collector_sync_t *sync,
+        ipintercept_t *ipint);
+static void move_ipintercept_cc_exclude_policy(ipintercept_t *destination,
+        ipintercept_t *source);
+
 collector_sync_t *init_sync_data(collector_global_t *glob) {
 
     int zero = 0, hwm = 2000;
@@ -61,6 +66,8 @@ collector_sync_t *init_sync_data(collector_global_t *glob) {
     sync->allusers = NULL;
     sync->x2x3_queues = NULL;
     sync->ipintercepts = NULL;
+    sync->ipcc_prefix_group_names = glob->ipcc_prefix_group_names;
+    sync->ipcc_prefix_group_count = glob->ipcc_prefix_group_count;
     sync->knownvoips = NULL;
     sync->userintercepts = NULL;
     sync->coreservers = NULL;
@@ -2166,6 +2173,11 @@ static int update_modified_intercept(collector_sync_t *sync,
         changed = 1;
     }
 
+    if (ipint->cc_exclude_mask != modified->cc_exclude_mask) {
+        changed = 1;
+    }
+    move_ipintercept_cc_exclude_policy(ipint, modified);
+
     if (encodingchanged) {
         expmsg = create_intercept_details_msg(&(ipint->common),
                 OPENLI_INTERCEPT_TYPE_IP);
@@ -2216,6 +2228,11 @@ static int modify_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
             logger(LOG_INFO,
                     "OpenLI: received invalid IP intercept modification from provisioner.");
         }
+        return -1;
+    }
+
+    if (resolve_ipintercept_cc_exclude_mask(sync, modified) < 0) {
+        free_single_ipintercept(modified);
         return -1;
     }
 
@@ -2706,6 +2723,42 @@ static int withdraw_x2x3_listener(collector_sync_t *sync, uint8_t *provmsg,
     return 1;
 }
 
+static int resolve_ipintercept_cc_exclude_mask(collector_sync_t *sync,
+        ipintercept_t *ipint) {
+    uint64_t mask = 0;
+    size_t i;
+    uint8_t j;
+
+    for (i = 0; i < ipint->cc_exclude_group_count; i++) {
+        for (j = 0; j < sync->ipcc_prefix_group_count; j++) {
+            if (strcmp(ipint->cc_exclude_groups[i],
+                    sync->ipcc_prefix_group_names[j]) == 0) {
+                mask |= UINT64_C(1) << j;
+                break;
+            }
+        }
+        if (j == sync->ipcc_prefix_group_count) {
+            logger(LOG_INFO,
+                    "OpenLI: IP intercept %s refers to unknown IPCC prefix exclusion group '%s'",
+                    ipint->common.liid, ipint->cc_exclude_groups[i]);
+            return -1;
+        }
+    }
+    ipint->cc_exclude_mask = mask;
+    return 0;
+}
+
+static void move_ipintercept_cc_exclude_policy(ipintercept_t *destination,
+        ipintercept_t *source) {
+    clear_ipintercept_cc_exclude_groups(destination);
+    destination->cc_exclude_groups = source->cc_exclude_groups;
+    destination->cc_exclude_group_count = source->cc_exclude_group_count;
+    destination->cc_exclude_mask = source->cc_exclude_mask;
+    source->cc_exclude_groups = NULL;
+    source->cc_exclude_group_count = 0;
+    source->cc_exclude_mask = 0;
+}
+
 static int new_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
         uint16_t msglen) {
 
@@ -2718,6 +2771,11 @@ static int new_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
                     "OpenLI: received invalid IP intercept from provisioner.");
         }
         free(cept);
+        return -1;
+    }
+
+    if (resolve_ipintercept_cc_exclude_mask(sync, cept) < 0) {
+        free_single_ipintercept(cept);
         return -1;
     }
 

--- a/src/collector/collector_sync.h
+++ b/src/collector/collector_sync.h
@@ -83,6 +83,8 @@ typedef struct colsync_data {
 
     internet_user_t *allusers;
     ipintercept_t *ipintercepts;
+    char **ipcc_prefix_group_names;
+    uint8_t ipcc_prefix_group_count;
     user_intercept_list_t *userintercepts;
     voipintercept_t *knownvoips;
     default_radius_user_t *defaultradiususers;

--- a/src/collector/configparser_collector.c
+++ b/src/collector/configparser_collector.c
@@ -27,6 +27,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <arpa/inet.h>
 
 #include <errno.h>
 #include <libtrace/message_queue.h>
@@ -39,6 +40,249 @@
 #include "configparser_collector.h"
 #include "configparser_common.h"
 #include "collector/x2x3_ingest.h"
+
+
+static int append_ipcc_prefix_config(collector_global_t *glob,
+        const char *value) {
+    size_t current_length = 0;
+    size_t value_length;
+    char *updated;
+
+    if (glob->ipcc_prefix_config != NULL) {
+        current_length = strlen(glob->ipcc_prefix_config);
+    }
+    value_length = strlen(value);
+
+    updated = realloc(glob->ipcc_prefix_config,
+            current_length + value_length + 2);
+    if (updated == NULL) {
+        return -1;
+    }
+
+    glob->ipcc_prefix_config = updated;
+    memcpy(glob->ipcc_prefix_config + current_length, value, value_length);
+    glob->ipcc_prefix_config[current_length + value_length] = '\n';
+    glob->ipcc_prefix_config[current_length + value_length + 1] = '\0';
+    return 0;
+}
+
+static int parse_ipcc_prefix(const char *text, int *family, void *address,
+        uint8_t *prefix_length) {
+    char buffer[INET6_ADDRSTRLEN + 5];
+    char *slash;
+    char *endptr;
+    unsigned long length;
+    size_t text_length;
+
+    text_length = strlen(text);
+    if (text_length == 0 || text_length >= sizeof(buffer)) {
+        return -1;
+    }
+
+    memcpy(buffer, text, text_length + 1);
+    slash = strrchr(buffer, '/');
+    if (slash == NULL || slash == buffer || slash[1] == '\0') {
+        return -1;
+    }
+
+    *slash = '\0';
+    errno = 0;
+    length = strtoul(slash + 1, &endptr, 10);
+    if (errno != 0 || *endptr != '\0') {
+        return -1;
+    }
+
+    if (inet_pton(AF_INET, buffer, address) == 1) {
+        if (length > 32) {
+            return -1;
+        }
+        *family = AF_INET;
+    } else if (inet_pton(AF_INET6, buffer, address) == 1) {
+        if (length > 128) {
+            return -1;
+        }
+        *family = AF_INET6;
+    } else {
+        return -1;
+    }
+
+    *prefix_length = (uint8_t)length;
+    return 0;
+}
+
+static int ipcc_prefix_group_exists(const collector_global_t *glob,
+        const char *name) {
+    uint8_t i;
+
+    for (i = 0; i < glob->ipcc_prefix_group_count; i++) {
+        if (strcmp(glob->ipcc_prefix_group_names[i], name) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int parse_ipcc_prefix_group(collector_global_t *glob,
+        yaml_document_t *doc, yaml_node_t *group, uint8_t group_id) {
+    yaml_node_pair_t *pair;
+    yaml_node_t *prefixes = NULL;
+    const char *name = NULL;
+    yaml_node_item_t *item;
+    size_t prefix_count = 0;
+
+    if (group->type != YAML_MAPPING_NODE) {
+        logger(LOG_INFO,
+                "OpenLI: each IPCC prefix exclusion group must be a mapping");
+        return -1;
+    }
+
+    for (pair = group->data.mapping.pairs.start;
+            pair < group->data.mapping.pairs.top; pair++) {
+        yaml_node_t *key = yaml_document_get_node(doc, pair->key);
+        yaml_node_t *value = yaml_document_get_node(doc, pair->value);
+
+        if (key->type != YAML_SCALAR_NODE) {
+            continue;
+        }
+
+        if (strcasecmp((char *)key->data.scalar.value, "name") == 0) {
+            if (value->type != YAML_SCALAR_NODE) {
+                logger(LOG_INFO,
+                        "OpenLI: IPCC prefix exclusion group name must be a scalar");
+                return -1;
+            }
+            name = (char *)value->data.scalar.value;
+        } else if (strcasecmp((char *)key->data.scalar.value,
+                "prefixes") == 0) {
+            if (value->type != YAML_SEQUENCE_NODE) {
+                logger(LOG_INFO,
+                        "OpenLI: IPCC prefix exclusion group prefixes must be a sequence");
+                return -1;
+            }
+            prefixes = value;
+        }
+    }
+
+    if (name == NULL || name[0] == '\0' || prefixes == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: each IPCC prefix exclusion group requires a name and prefixes");
+        return -1;
+    }
+
+    if (ipcc_prefix_group_exists(glob, name)) {
+        logger(LOG_INFO,
+                "OpenLI: duplicate IPCC prefix exclusion group name '%s'", name);
+        return -1;
+    }
+
+    glob->ipcc_prefix_group_names[group_id] = strdup(name);
+    if (glob->ipcc_prefix_group_names[group_id] == NULL ||
+            append_ipcc_prefix_config(glob, name) < 0) {
+        logger(LOG_INFO,
+                "OpenLI: unable to allocate IPCC prefix exclusion group '%s'", name);
+        return -1;
+    }
+    glob->ipcc_prefix_group_count++;
+
+    for (item = prefixes->data.sequence.items.start;
+            item < prefixes->data.sequence.items.top; item++) {
+        yaml_node_t *prefix = yaml_document_get_node(doc, *item);
+        uint8_t address[sizeof(struct in6_addr)];
+        uint8_t prefix_length;
+        int family;
+        const char *prefix_text;
+        openli_cc_prefix_filter_result_t result;
+
+        if (prefix->type != YAML_SCALAR_NODE) {
+            logger(LOG_INFO,
+                    "OpenLI: prefixes in IPCC exclusion group '%s' must be scalars",
+                    name);
+            return -1;
+        }
+
+        prefix_text = (char *)prefix->data.scalar.value;
+        memset(address, 0, sizeof(address));
+        if (parse_ipcc_prefix(prefix_text, &family, address,
+                &prefix_length) < 0) {
+            logger(LOG_INFO, "OpenLI: invalid IPCC prefix '%s' in group '%s'",
+                    prefix_text, name);
+            return -1;
+        }
+
+        result = openli_cc_prefix_filter_add(glob->ipcc_prefix_filter,
+                family, address, prefix_length, group_id);
+        if (result == OPENLI_CC_PREFIX_FILTER_DUPLICATE) {
+            logger(LOG_INFO,
+                    "OpenLI: duplicate IPCC prefix '%s' in group '%s'",
+                    prefix_text, name);
+            return -1;
+        }
+        if (result != OPENLI_CC_PREFIX_FILTER_OK) {
+            logger(LOG_INFO,
+                    "OpenLI: unable to add IPCC prefix '%s' to group '%s': %s",
+                    prefix_text, name,
+                    openli_cc_prefix_filter_result_string(result));
+            return -1;
+        }
+
+        if (append_ipcc_prefix_config(glob, prefix_text) < 0) {
+            logger(LOG_INFO,
+                    "OpenLI: unable to store IPCC prefix configuration");
+            return -1;
+        }
+        prefix_count++;
+    }
+
+    if (prefix_count == 0) {
+        logger(LOG_INFO,
+                "OpenLI: IPCC prefix exclusion group '%s' has no prefixes", name);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int parse_ipcc_prefix_groups(collector_global_t *glob,
+        yaml_document_t *doc, yaml_node_t *groups) {
+    yaml_node_item_t *item;
+
+    if (glob->ipcc_prefix_filter != NULL) {
+        logger(LOG_INFO,
+                "OpenLI: IPCC prefix exclusion groups may only be configured once");
+        return -1;
+    }
+
+    glob->ipcc_prefix_filter = openli_cc_prefix_filter_create();
+    if (glob->ipcc_prefix_filter == NULL) {
+        logger(LOG_INFO, "OpenLI: unable to allocate IPCC prefix filter");
+        return -1;
+    }
+
+    for (item = groups->data.sequence.items.start;
+            item < groups->data.sequence.items.top; item++) {
+        yaml_node_t *group = yaml_document_get_node(doc, *item);
+        uint8_t group_id = glob->ipcc_prefix_group_count;
+
+        if (group_id >= OPENLI_CC_PREFIX_FILTER_MAX_GROUPS) {
+            logger(LOG_INFO,
+                    "OpenLI: no more than %u IPCC prefix exclusion groups may be configured",
+                    OPENLI_CC_PREFIX_FILTER_MAX_GROUPS);
+            return -1;
+        }
+
+        if (parse_ipcc_prefix_group(glob, doc, group, group_id) < 0) {
+            return -1;
+        }
+    }
+
+    if (glob->ipcc_prefix_group_count == 0) {
+        logger(LOG_INFO,
+                "OpenLI: IPCC prefix exclusion group list must not be empty");
+        return -1;
+    }
+
+    return 0;
+}
 
 static int parse_udp_sink_config(collector_global_t *glob,
         yaml_document_t *doc, yaml_node_t *sinks) {
@@ -470,6 +714,13 @@ static int collector_parser(void *arg, yaml_document_t *doc,
 
     if (key->type == YAML_SCALAR_NODE &&
             value->type == YAML_SEQUENCE_NODE &&
+            strcasecmp((char *)key->data.scalar.value,
+                    "ipcc-exclude-prefix-groups") == 0) {
+        return parse_ipcc_prefix_groups(glob, doc, value);
+    }
+
+    if (key->type == YAML_SCALAR_NODE &&
+            value->type == YAML_SEQUENCE_NODE &&
             strcasecmp((char *)key->data.scalar.value, "inputs") == 0) {
         if (parse_input_config(glob, doc, value) == -1) {
             return -1;
@@ -872,7 +1123,36 @@ static int collector_parser(void *arg, yaml_document_t *doc,
 }
 
 int parse_collector_config(char *configfile, collector_global_t *glob) {
-    return config_yaml_parser(configfile, glob, collector_parser, 0, NULL);
+    int result;
+    uint8_t i;
+
+    result = config_yaml_parser(configfile, glob, collector_parser, 0, NULL);
+    if (result < 0) {
+        return result;
+    }
+
+    if (glob->ipcc_prefix_filter == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: no IPCC prefix exclusion groups configured");
+        return 0;
+    }
+
+    if (openli_cc_prefix_filter_finalise(glob->ipcc_prefix_filter) !=
+            OPENLI_CC_PREFIX_FILTER_OK) {
+        logger(LOG_INFO, "OpenLI: unable to finalise IPCC prefix filter");
+        return -1;
+    }
+
+    logger(LOG_INFO,
+            "OpenLI: IPCC prefix exclusion filter loaded: %u groups, %zu IPv4 prefixes, %zu IPv6 prefixes",
+            glob->ipcc_prefix_group_count,
+            openli_cc_prefix_filter_count(glob->ipcc_prefix_filter, AF_INET),
+            openli_cc_prefix_filter_count(glob->ipcc_prefix_filter, AF_INET6));
+    for (i = 0; i < glob->ipcc_prefix_group_count; i++) {
+        logger(LOG_INFO, "OpenLI: IPCC prefix exclusion group %u: '%s'",
+                i, glob->ipcc_prefix_group_names[i]);
+    }
+    return 0;
 }
 
 char *collector_config_to_json(collector_global_t *glob) {

--- a/src/collector/ipcc.c
+++ b/src/collector/ipcc.c
@@ -39,6 +39,36 @@
 #include "etsili_core.h"
 #include "ipcc.h"
 
+static inline uint64_t packet_cc_exclude_mask(packet_info_t *pinfo,
+        int family, colthread_local_t *loc) {
+    const void *src;
+    const void *dst;
+    uint64_t mask;
+
+    if (loc->ipcc_prefix_filter == NULL) {
+        return 0;
+    }
+
+    if (family == AF_INET) {
+        src = &((struct sockaddr_in *)&pinfo->srcip)->sin_addr;
+        dst = &((struct sockaddr_in *)&pinfo->destip)->sin_addr;
+    } else {
+        src = &((struct sockaddr_in6 *)&pinfo->srcip)->sin6_addr;
+        dst = &((struct sockaddr_in6 *)&pinfo->destip)->sin6_addr;
+    }
+
+    mask = openli_cc_prefix_filter_match(loc->ipcc_prefix_filter,
+            family, src);
+    mask |= openli_cc_prefix_filter_match(loc->ipcc_prefix_filter,
+            family, dst);
+    return mask;
+}
+
+static inline int suppress_ipcc(uint64_t packet_mask,
+        uint64_t intercept_mask) {
+    return packet_mask != 0 && (packet_mask & intercept_mask) != 0;
+}
+
 static inline static_ipcache_t *find_static_cached(prefix_t *prefix,
         colthread_local_t *loc) {
 
@@ -79,7 +109,8 @@ static inline int add_static_cached(prefix_t *prefix, patricia_node_t *pnode,
 
 static inline int lookup_static_ranges(struct sockaddr *cmp,
         int family, libtrace_packet_t *pkt, uint8_t dir,
-        colthread_local_t *loc, struct timeval *tv) {
+        colthread_local_t *loc, struct timeval *tv,
+        uint64_t packet_mask) {
 
     int matched = 0;
     patricia_node_t *pnode = NULL;
@@ -143,6 +174,11 @@ static inline int lookup_static_ranges(struct sockaddr *cmp,
                     continue;
                 }
 
+                if (suppress_ipcc(packet_mask,
+                        matchsess->cc_exclude_mask)) {
+                    continue;
+                }
+
                 matched ++;
                 if (matchsess->common.targetagency == NULL ||
                         strcmp(matchsess->common.targetagency, "pcapdisk") == 0)
@@ -168,7 +204,7 @@ static inline int lookup_static_ranges(struct sockaddr *cmp,
 
 static void singlev6_conn_contents(struct sockaddr_in6 *cmp,
         colthread_local_t *loc, int *matched, libtrace_packet_t *pkt,
-        struct timeval *tv) {
+        struct timeval *tv, uint64_t packet_mask) {
 
     patricia_node_t *pnode = NULL;
     prefix_t prefix;
@@ -211,6 +247,11 @@ static void singlev6_conn_contents(struct sockaddr_in6 *cmp,
                         continue;
                     }
 
+                    if (suppress_ipcc(packet_mask,
+                            sess->cc_exclude_mask)) {
+                        continue;
+                    }
+
                     *matched = ((*matched) + 1);
                     if (sess->common.targetagency == NULL ||
                             strcmp(sess->common.targetagency,"pcapdisk") == 0) {
@@ -244,6 +285,7 @@ int ipv6_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
 
     struct sockaddr_in6 *cmp;
     int matched = 0;
+    uint64_t packet_mask;
 
     if (rem < sizeof(libtrace_ip6_t)) {
         /* Truncated IP header */
@@ -254,16 +296,20 @@ int ipv6_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
     /* Check if ipsrc or ipdst match any of our active intercepts.
      * NOTE: a packet can match multiple intercepts so don't break early.
      */
+    packet_mask = packet_cc_exclude_mask(pinfo, AF_INET6, loc);
+
     cmp = (struct sockaddr_in6 *)(&pinfo->srcip);
-    singlev6_conn_contents(cmp, loc, &matched, pkt, &pinfo->tv);
+    singlev6_conn_contents(cmp, loc, &matched, pkt, &pinfo->tv,
+            packet_mask);
 
     cmp = (struct sockaddr_in6 *)(&pinfo->destip);
-    singlev6_conn_contents(cmp, loc, &matched, pkt, &pinfo->tv);
+    singlev6_conn_contents(cmp, loc, &matched, pkt, &pinfo->tv,
+            packet_mask);
 
     matched += lookup_static_ranges((struct sockaddr *)(&pinfo->srcip),
-            AF_INET6, pkt, 0, loc, &pinfo->tv);
+            AF_INET6, pkt, 0, loc, &pinfo->tv, packet_mask);
     matched += lookup_static_ranges((struct sockaddr *)(&pinfo->destip),
-            AF_INET6, pkt, 1, loc, &pinfo->tv);
+            AF_INET6, pkt, 1, loc, &pinfo->tv, packet_mask);
 
     return matched;
 }
@@ -275,6 +321,7 @@ int ipv4_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
     struct sockaddr_in *cmp;
     openli_export_recv_t *msg;
     int matched = 0;
+    uint64_t packet_mask;
     ipv4_target_t *tgt;
     ipsession_t *sess, *tmp;
 
@@ -287,6 +334,8 @@ int ipv4_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
     /* Check if ipsrc or ipdst match any of our active intercepts.
      * NOTE: a packet can match multiple intercepts so don't break early.
      */
+
+    packet_mask = packet_cc_exclude_mask(pinfo, AF_INET, loc);
 
     cmp = (struct sockaddr_in *)(&pinfo->srcip);
     HASH_FIND(hh, loc->activeipv4intercepts, &(cmp->sin_addr.s_addr),
@@ -303,6 +352,10 @@ int ipv4_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
 
             if (sess->common.toend_time > 0 && pinfo->tv.tv_sec >=
                     sess->common.toend_time) {
+                continue;
+            }
+
+            if (suppress_ipcc(packet_mask, sess->cc_exclude_mask)) {
                 continue;
             }
 
@@ -345,6 +398,10 @@ int ipv4_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
                 continue;
             }
 
+            if (suppress_ipcc(packet_mask, sess->cc_exclude_mask)) {
+                continue;
+            }
+
             matched ++;
             if (sess->common.targetagency == NULL ||
                     strcmp(sess->common.targetagency, "pcapdisk") == 0) {
@@ -371,9 +428,9 @@ int ipv4_comm_contents(libtrace_packet_t *pkt, packet_info_t *pinfo,
     }
 
     matched += lookup_static_ranges((struct sockaddr *)(&pinfo->srcip),
-            AF_INET, pkt, 0, loc, &pinfo->tv);
+            AF_INET, pkt, 0, loc, &pinfo->tv, packet_mask);
     matched += lookup_static_ranges((struct sockaddr *)(&pinfo->destip),
-            AF_INET, pkt, 1, loc, &pinfo->tv);
+            AF_INET, pkt, 1, loc, &pinfo->tv, packet_mask);
 
 
 ipv4ccdone:

--- a/src/collector/jmirror_parser.c
+++ b/src/collector/jmirror_parser.c
@@ -76,6 +76,7 @@ int check_jmirror_intercept(colthread_local_t *loc,
 
     coreserver_t *cs;
     uint32_t rem = 0, cept_id, cin, bodylen;
+    uint64_t packet_mask;
     vendmirror_intercept_t *cept, *tmp;
     vendmirror_intercept_list_t *vmilist;
     uint8_t *l3, *start;
@@ -96,6 +97,9 @@ int check_jmirror_intercept(colthread_local_t *loc,
         return 0;
     }
 
+    packet_mask = openli_cc_prefix_filter_match_l3(
+            loc->ipcc_prefix_filter, l3, bodylen);
+
     HASH_ITER(hh, vmilist->intercepts, cept, tmp) {
         if (pinfo->tv.tv_sec < cept->common.tostart_time) {
             continue;
@@ -104,7 +108,12 @@ int check_jmirror_intercept(colthread_local_t *loc,
                 cept->common.toend_time < pinfo->tv.tv_sec) {
             continue;
         }
-                /* Create an appropriate IPCC and export it */
+                if (packet_mask != 0 &&
+                (packet_mask & cept->cc_exclude_mask) != 0) {
+            continue;
+        }
+
+        /* Create an appropriate IPCC and export it */
         if (push_vendor_mirrored_ipcc_job(
                 loc->zmq_pubsocks[cept->common.seqtrackerid], &(cept->common),
                 trace_get_timeval(packet), cin, ETSI_DIR_INDETERMINATE,

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -697,6 +697,66 @@ void remove_all_intercept_udp_sinks(ipintercept_t *cept) {
     }
 }
 
+
+void clear_ipintercept_cc_exclude_groups(ipintercept_t *cept) {
+    size_t i;
+
+    if (cept == NULL) {
+        return;
+    }
+    for (i = 0; i < cept->cc_exclude_group_count; i++) {
+        free(cept->cc_exclude_groups[i]);
+    }
+    free(cept->cc_exclude_groups);
+    cept->cc_exclude_groups = NULL;
+    cept->cc_exclude_group_count = 0;
+    cept->cc_exclude_mask = 0;
+}
+
+int add_ipintercept_cc_exclude_group(ipintercept_t *cept,
+        const char *group, size_t group_len) {
+    char **updated;
+    char *copy;
+    size_t i;
+
+    if (cept == NULL || group == NULL || group_len == 0 ||
+            cept->cc_exclude_group_count >= 64) {
+        return -1;
+    }
+    for (i = 0; i < cept->cc_exclude_group_count; i++) {
+        if (strlen(cept->cc_exclude_groups[i]) == group_len &&
+                memcmp(cept->cc_exclude_groups[i], group, group_len) == 0) {
+            return -1;
+        }
+    }
+    copy = malloc(group_len + 1);
+    if (copy == NULL) {
+        return -1;
+    }
+    memcpy(copy, group, group_len);
+    copy[group_len] = '\0';
+
+    updated = realloc(cept->cc_exclude_groups,
+            (cept->cc_exclude_group_count + 1) * sizeof(char *));
+    if (updated == NULL) {
+        free(copy);
+        return -1;
+    }
+    cept->cc_exclude_groups = updated;
+    cept->cc_exclude_groups[cept->cc_exclude_group_count++] = copy;
+    return 0;
+}
+
+size_t ipintercept_cc_exclude_encoded_length(const ipintercept_t *cept) {
+    size_t total = 0;
+    size_t i;
+
+    for (i = 0; i < cept->cc_exclude_group_count; i++) {
+        total += strlen(cept->cc_exclude_groups[i]) + 4;
+    }
+    return total;
+}
+
 void free_single_ipintercept(ipintercept_t *cept) {
     intercept_udp_sink_t *sink, *tmp;
 
@@ -711,6 +771,7 @@ void free_single_ipintercept(ipintercept_t *cept) {
     }
 
     free_all_staticipranges(&(cept->statics));
+    clear_ipintercept_cc_exclude_groups(cept);
     free(cept);
 }
 
@@ -1246,6 +1307,7 @@ ipsession_t *create_ipsession(ipintercept_t *ipint, uint32_t cin,
     }
     memcpy(ipsess->targetip, assignedip, sizeof(struct sockaddr_storage));
     ipsess->accesstype = ipint->accesstype;
+    ipsess->cc_exclude_mask = ipint->cc_exclude_mask;
 
     copy_intercept_common(&(ipint->common), &(ipsess->common));
 

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -1202,6 +1202,7 @@ vendmirror_intercept_t *create_vendmirror_intercept(ipintercept_t *ipint) {
     }
 
     jm->sessionid = ipint->vendmirrorid;
+    jm->cc_exclude_mask = ipint->cc_exclude_mask;
     copy_intercept_common(&(ipint->common), &(jm->common));
 
     return jm;

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -1247,6 +1247,7 @@ staticipsession_t *create_staticipsession(ipintercept_t *ipint, char *rangestr,
     statint->references = 0;
     statint->cin = cin;
     statint->nextseqno = 0;
+    statint->cc_exclude_mask = ipint->cc_exclude_mask;
     copy_intercept_common(&(ipint->common), &(statint->common));
     statint->key = (char *)calloc(1, 128);
     snprintf(statint->key, 127, "%s-%u", ipint->common.liid, cin);

--- a/src/intercept.h
+++ b/src/intercept.h
@@ -579,6 +579,7 @@ struct ipsession {
 
 struct vendmirror_intercept {
     uint32_t sessionid;
+    uint64_t cc_exclude_mask;
     intercept_common_t common;
     UT_hash_handle hh;
 };

--- a/src/intercept.h
+++ b/src/intercept.h
@@ -240,6 +240,10 @@ typedef struct ipintercept {
 
     static_ipranges_t *statics;
 
+    char **cc_exclude_groups;
+    size_t cc_exclude_group_count;
+    uint64_t cc_exclude_mask;
+
     openli_mobile_identifier_t mobileident;
     uint8_t awaitingconfirm;
     uint32_t options;
@@ -567,6 +571,7 @@ struct ipsession {
     uint8_t prefixlen;
     uint32_t nextseqno;
     internet_access_method_t accesstype;
+    uint64_t cc_exclude_mask;
 
     intercept_common_t common;
     UT_hash_handle hh;
@@ -622,6 +627,10 @@ void free_single_register(sipregister_t *sipr);
 void free_single_voip_cinmap_entry(voipcinmap_t *c);
 void free_voip_cinmap(voipcinmap_t *cins);
 void free_single_ipintercept(ipintercept_t *cept);
+void clear_ipintercept_cc_exclude_groups(ipintercept_t *cept);
+int add_ipintercept_cc_exclude_group(ipintercept_t *cept,
+        const char *group, size_t group_len);
+size_t ipintercept_cc_exclude_encoded_length(const ipintercept_t *cept);
 void free_single_voipintercept(voipintercept_t *v);
 void free_single_emailintercept(emailintercept_t *m);
 void free_single_ipsession(ipsession_t *sess);

--- a/src/intercept.h
+++ b/src/intercept.h
@@ -596,6 +596,7 @@ struct staticipsession {
     uint32_t cin;
     uint32_t nextseqno;
     uint32_t references;
+    uint64_t cc_exclude_mask;
     UT_hash_handle hh;
 };
 

--- a/src/netcomms.c
+++ b/src/netcomms.c
@@ -679,7 +679,7 @@ int push_lea_withdrawal_onto_net_buffer(net_buffer_t *nb, liagency_t *lea) {
         (INTERCEPT_COMMON_LEN(ipint->common) + \
          ipint->username_len + sizeof(ipint->options) + \
          sizeof(ipint->accesstype) + sizeof(ipint->mobileident) + \
-         (4 * 4))
+         ipintercept_cc_exclude_encoded_length(ipint) + (4 * 4))
 
 #define VENDMIRROR_IPINTERCEPT_BODY_LEN(ipint) \
         (IPINTERCEPT_BODY_LEN(ipint) + sizeof(ipint->vendmirrorid) + 4)
@@ -786,6 +786,20 @@ static int _push_intercept_common_fields(net_buffer_t *nb,
     return 0;
 }
 
+static int push_ipintercept_cc_exclude_groups(net_buffer_t *nb,
+        const ipintercept_t *ipint) {
+    size_t i;
+
+    for (i = 0; i < ipint->cc_exclude_group_count; i++) {
+        if (push_tlv(nb, OPENLI_PROTO_FIELD_IPCC_EXCLUDE_GROUP,
+                (uint8_t *)ipint->cc_exclude_groups[i],
+                strlen(ipint->cc_exclude_groups[i])) == -1) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static int _push_ipintercept_modify(net_buffer_t *nb, ipintercept_t *ipint) {
 
     ii_header_t hdr;
@@ -831,6 +845,10 @@ static int _push_ipintercept_modify(net_buffer_t *nb, ipintercept_t *ipint) {
     if (push_tlv(nb, OPENLI_PROTO_FIELD_INTOPTIONS,
             (uint8_t *)(&(ipint->options)),
             sizeof(ipint->options)) == -1) {
+        goto pushmodfail;
+    }
+
+    if (push_ipintercept_cc_exclude_groups(nb, ipint) == -1) {
         goto pushmodfail;
     }
 
@@ -1457,6 +1475,10 @@ int push_ipintercept_onto_net_buffer(net_buffer_t *nb, void *data) {
     if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_INTOPTIONS,
             (uint8_t *)(&ipint->options),
             sizeof(ipint->options))) == -1) {
+        goto pushipintfail;
+    }
+
+    if (push_ipintercept_cc_exclude_groups(nb, ipint) == -1) {
         goto pushipintfail;
     }
 
@@ -2299,6 +2321,9 @@ int decode_ipintercept_start(uint8_t *msgbody, uint16_t len,
     ipint->accesstype = INTERNET_ACCESS_TYPE_UNDEFINED;
     ipint->statics = NULL;
     ipint->options = 0;
+    ipint->cc_exclude_groups = NULL;
+    ipint->cc_exclude_group_count = 0;
+    ipint->cc_exclude_mask = 0;
     ipint->mobileident = OPENLI_MOBILE_IDENTIFIER_NOT_SPECIFIED;
 
     init_decoded_intercept_common(&(ipint->common));
@@ -2333,6 +2358,11 @@ int decode_ipintercept_start(uint8_t *msgbody, uint16_t len,
             ipint->mobileident = *((openli_mobile_identifier_t *)valptr);
         } else if (f == OPENLI_PROTO_FIELD_INTOPTIONS) {
             ipint->options = *((uint32_t *)valptr);
+        } else if (f == OPENLI_PROTO_FIELD_IPCC_EXCLUDE_GROUP) {
+            if (add_ipintercept_cc_exclude_group(ipint,
+                    (char *)valptr, vallen) < 0) {
+                return -1;
+            }
         } else if (f == OPENLI_PROTO_FIELD_USERNAME) {
             DECODE_STRING_FIELD(ipint->username, valptr, vallen);
             if (vallen == 0) {

--- a/src/netcomms.h
+++ b/src/netcomms.h
@@ -259,6 +259,7 @@ typedef enum {
     OPENLI_PROTO_FIELD_OPERATORID,
     OPENLI_PROTO_FIELD_SHORTOPERATORID,
     OPENLI_PROTO_FIELD_ISACTIVE,
+    OPENLI_PROTO_FIELD_IPCC_EXCLUDE_GROUP,
 } openli_proto_fieldtype_t;
 /* XXX one day we may need to separate these field types into distinct
  * enums for each "message type" as there is only one byte available for

--- a/src/provisioner/configparser_provisioner.c
+++ b/src/provisioner/configparser_provisioner.c
@@ -1198,6 +1198,9 @@ static int parse_ipintercept_list(ipintercept_t **ipints, yaml_document_t *doc,
         newcept->accesstype = INTERNET_ACCESS_TYPE_UNDEFINED;
         newcept->mobileident = OPENLI_MOBILE_IDENTIFIER_NOT_SPECIFIED;
         newcept->statics = NULL;
+        newcept->cc_exclude_groups = NULL;
+        newcept->cc_exclude_group_count = 0;
+        newcept->cc_exclude_mask = 0;
         newcept->options = 0;
 
         /* Mappings describe the parameters for each intercept */
@@ -1215,6 +1218,29 @@ static int parse_ipintercept_list(ipintercept_t **ipints, yaml_document_t *doc,
                     strcasecmp((char *)key->data.scalar.value,
                             "staticips") == 0) {
                 add_intercept_static_ips(&(newcept->statics), doc, value);
+            }
+
+            if (key->type == YAML_SCALAR_NODE &&
+                    value->type == YAML_SEQUENCE_NODE &&
+                    strcasecmp((char *)key->data.scalar.value,
+                            "cc_exclude_groups") == 0) {
+                yaml_node_item_t *groupitem;
+
+                for (groupitem = value->data.sequence.items.start;
+                        groupitem < value->data.sequence.items.top;
+                        groupitem++) {
+                    yaml_node_t *group = yaml_document_get_node(doc,
+                            *groupitem);
+                    if (group->type != YAML_SCALAR_NODE ||
+                            add_ipintercept_cc_exclude_group(newcept,
+                            (char *)group->data.scalar.value,
+                            group->data.scalar.length) < 0) {
+                        logger(LOG_INFO,
+                                "OpenLI: invalid or duplicate cc_exclude_groups entry in IP intercept configuration");
+                        free_single_ipintercept(newcept);
+                        return -1;
+                    }
+                }
             }
 
             if (key->type == YAML_SCALAR_NODE &&

--- a/src/provisioner/configwriter.c
+++ b/src/provisioner/configwriter.c
@@ -870,6 +870,7 @@ static int emit_ipintercepts(ipintercept_t *ipints, yaml_emitter_t *emitter) {
     ipintercept_t *ipint, *tmp;
     char buffer[64];
     const char *accesstype;
+    size_t i;
 
     yaml_scalar_event_initialize(&event, NULL, (yaml_char_t *)YAML_STR_TAG,
             (yaml_char_t *)"ipintercepts", strlen("ipintercepts"), 1, 0,
@@ -907,6 +908,32 @@ static int emit_ipintercepts(ipintercept_t *ipints, yaml_emitter_t *emitter) {
                 (yaml_char_t *)ipint->username, strlen(ipint->username), 1, 0,
                 YAML_PLAIN_SCALAR_STYLE);
         if (!yaml_emitter_emit(emitter, &event)) return -1;
+
+        if (ipint->cc_exclude_group_count > 0) {
+            yaml_scalar_event_initialize(&event, NULL,
+                    (yaml_char_t *)YAML_STR_TAG,
+                    (yaml_char_t *)"cc_exclude_groups",
+                    strlen("cc_exclude_groups"), 1, 0,
+                    YAML_PLAIN_SCALAR_STYLE);
+            if (!yaml_emitter_emit(emitter, &event)) return -1;
+
+            yaml_sequence_start_event_initialize(&event, NULL,
+                    (yaml_char_t *)YAML_SEQ_TAG, 1,
+                    YAML_ANY_SEQUENCE_STYLE);
+            if (!yaml_emitter_emit(emitter, &event)) return -1;
+
+            for (i = 0; i < ipint->cc_exclude_group_count; i++) {
+                yaml_scalar_event_initialize(&event, NULL,
+                        (yaml_char_t *)YAML_STR_TAG,
+                        (yaml_char_t *)ipint->cc_exclude_groups[i],
+                        strlen(ipint->cc_exclude_groups[i]), 1, 0,
+                        YAML_PLAIN_SCALAR_STYLE);
+                if (!yaml_emitter_emit(emitter, &event)) return -1;
+            }
+
+            yaml_sequence_end_event_initialize(&event);
+            if (!yaml_emitter_emit(emitter, &event)) return -1;
+        }
 
         if (ipint->accesstype != INTERNET_ACCESS_TYPE_UNDEFINED) {
             yaml_scalar_event_initialize(&event, NULL,

--- a/src/provisioner/updateserver_jsoncreation.c
+++ b/src/provisioner/updateserver_jsoncreation.c
@@ -275,7 +275,8 @@ static void convert_commonintercept_to_json(json_object *jobj,
 static json_object *convert_ipintercept_to_json(ipintercept_t *ipint) {
     json_object *jobj;
     json_object *vendmirrorid, *user, *accesstype, *radiusident;
-    json_object *staticips, *mobileident, *udpsinks;
+    json_object *staticips, *mobileident, *udpsinks, *ccgroups;
+    size_t i;
 
     jobj = json_object_new_object();
     convert_commonintercept_to_json(jobj, &(ipint->common));
@@ -289,6 +290,13 @@ static json_object *convert_ipintercept_to_json(ipintercept_t *ipint) {
     json_object_object_add(jobj, "user", user);
     json_object_object_add(jobj, "accesstype", accesstype);
     json_object_object_add(jobj, "radiusident", radiusident);
+
+    ccgroups = json_object_new_array();
+    for (i = 0; i < ipint->cc_exclude_group_count; i++) {
+        json_object_array_add(ccgroups,
+                json_object_new_string(ipint->cc_exclude_groups[i]));
+    }
+    json_object_object_add(jobj, "cc_exclude_groups", ccgroups);
 
     if (ipint->mobileident != OPENLI_MOBILE_IDENTIFIER_NOT_SPECIFIED) {
         mobileident = json_object_new_string(

--- a/src/provisioner/updateserver_jsonparsing.c
+++ b/src/provisioner/updateserver_jsonparsing.c
@@ -79,6 +79,7 @@ struct json_intercept {
     struct json_object *xids;
     struct json_object *xid;
     struct json_object *udpsinks;
+    struct json_object *cc_exclude_groups;
 };
 
 struct json_prov_options {
@@ -253,6 +254,8 @@ static inline void extract_intercept_json_objects(
     json_object_object_get_ex(parsed, "vendmirrorid", &(ipjson->vendmirrorid));
     json_object_object_get_ex(parsed, "staticips", &(ipjson->staticips));
     json_object_object_get_ex(parsed, "udpsinks", &(ipjson->udpsinks));
+    json_object_object_get_ex(parsed, "cc_exclude_groups",
+            &(ipjson->cc_exclude_groups));
     json_object_object_get_ex(parsed, "siptargets", &(ipjson->siptargets));
     json_object_object_get_ex(parsed, "targets", &(ipjson->emailtargets));
     json_object_object_get_ex(parsed, "delivercompressed", &(ipjson->delivercompressed));
@@ -1722,6 +1725,49 @@ sinkerr:
     return -1;
 }
 
+static int parse_ipintercept_cc_exclude_groups(ipintercept_t *ipint,
+        struct json_object *groups, update_con_info_t *cinfo) {
+    size_t i;
+    size_t count;
+
+    if (!json_object_is_type(groups, json_type_array)) {
+        snprintf(cinfo->answerstring, 4096,
+                "%s <p>cc_exclude_groups for an IP intercept must be an array of strings. %s",
+                update_failure_page_start, update_failure_page_end);
+        return -1;
+    }
+
+    count = json_object_array_length(groups);
+    if (count > 64) {
+        snprintf(cinfo->answerstring, 4096,
+                "%s <p>An IP intercept may specify no more than 64 cc_exclude_groups. %s",
+                update_failure_page_start, update_failure_page_end);
+        return -1;
+    }
+
+    for (i = 0; i < count; i++) {
+        struct json_object *entry = json_object_array_get_idx(groups, i);
+        const char *name;
+
+        if (!json_object_is_type(entry, json_type_string)) {
+            snprintf(cinfo->answerstring, 4096,
+                    "%s <p>Each cc_exclude_groups entry must be a string. %s",
+                    update_failure_page_start, update_failure_page_end);
+            return -1;
+        }
+        name = json_object_get_string(entry);
+        if (name == NULL || name[0] == '\0' ||
+                add_ipintercept_cc_exclude_group(ipint, name,
+                        strlen(name)) < 0) {
+            snprintf(cinfo->answerstring, 4096,
+                    "%s <p>cc_exclude_groups contains an empty or duplicate group name. %s",
+                    update_failure_page_start, update_failure_page_end);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 static int parse_ipintercept_staticips(ipintercept_t *ipint,
         struct json_object *jsonips, update_con_info_t *cinfo) {
 
@@ -2184,6 +2230,12 @@ int add_new_ipintercept(update_con_info_t *cinfo, provision_state_t *state) {
             mobileidentstring, &parseerr, false);
 
     if (parseerr) {
+        goto cepterr;
+    }
+
+    if (ipjson.cc_exclude_groups != NULL &&
+            parse_ipintercept_cc_exclude_groups(ipint,
+                    ipjson.cc_exclude_groups, cinfo) < 0) {
         goto cepterr;
     }
 
@@ -2813,6 +2865,31 @@ int modify_ipintercept(update_con_info_t *cinfo, provision_state_t *state) {
         goto cepterr;
     }
 
+    if (ipjson.cc_exclude_groups != NULL &&
+            parse_ipintercept_cc_exclude_groups(ipint,
+                    ipjson.cc_exclude_groups, cinfo) < 0) {
+        goto cepterr;
+    }
+
+    /* Preserve optional common fields that were omitted from this partial
+     * update. update_intercept_common() compares the parsed values directly,
+     * so leaving integer fields at their calloc() default would otherwise
+     * overwrite the active intercept with zero before later validation.
+     */
+    if (ipjson.agencyid == NULL) {
+        ipint->common.targetagency =
+                strdup(found->common.targetagency);
+        if (ipint->common.targetagency == NULL) {
+            goto cepterr;
+        }
+    }
+    if (ipjson.mediator == NULL) {
+        ipint->common.destid = found->common.destid;
+    }
+    if (ipjson.tomediate == NULL) {
+        ipint->common.tomediate = found->common.tomediate;
+    }
+
     if (set_agency_properties(state, &(ipint->common), cinfo) < 0) {
         goto cepterr;
     }
@@ -2970,8 +3047,7 @@ int modify_ipintercept(update_con_info_t *cinfo, provision_state_t *state) {
     if (radiusidentstring) {
         ipint->options = map_radius_ident_string(radiusidentstring);
     } else {
-        ipint->options = (1 << OPENLI_IPINT_OPTION_RADIUS_IDENT_USER) |
-                (1 << OPENLI_IPINT_OPTION_RADIUS_IDENT_CSID);
+        ipint->options = found->options;
     }
 
     if (ipint->accesstype != INTERNET_ACCESS_TYPE_MOBILE) {
@@ -3005,6 +3081,15 @@ int modify_ipintercept(update_con_info_t *cinfo, provision_state_t *state) {
             ipint->vendmirrorid != found->vendmirrorid) {
         changed = 1;
         found->vendmirrorid = ipint->vendmirrorid;
+    }
+
+    if (ipjson.cc_exclude_groups != NULL) {
+        clear_ipintercept_cc_exclude_groups(found);
+        found->cc_exclude_groups = ipint->cc_exclude_groups;
+        found->cc_exclude_group_count = ipint->cc_exclude_group_count;
+        ipint->cc_exclude_groups = NULL;
+        ipint->cc_exclude_group_count = 0;
+        changed = 1;
     }
 
     if (agencychanged) {


### PR DESCRIPTION
## Summary

Adds support for configurable IP CC prefix exclusion groups on a per-intercept basis.

Collectors can now define named groups of IPv4/IPv6 prefixes. Individual IP intercepts select which groups to apply via `cc_exclude_groups`.

When an intercepted packet's source or destination IP matches a prefix in an assigned group, CC generation is suppressed for that specific intercept. IRI generation remains unaffected.

## Configuration

Example collector configuration:

    ipcc-exclude-prefix-groups:
      - name: oper-iptv
        prefixes:
          - 192.0.2.0/24

      - name: netflix-cache
        prefixes:
          - 198.18.10.0/24

      - name: iperf-public
        prefixes:
          - 198.20.10.0/24
          - 198.24.10.0/24
          - 198.26.10.0/24

Example intercept property:

    cc_exclude_groups:
      - oper-iptv
      - netflix-cache

Key constraints:
* Max 64 groups supported globally (represented internally as a 64-bit mask).
* Overlapping prefixes across different groups are rejected during validation to ensure deterministic Trie lookups.

## REST API

Exposed via `cc_exclude_groups` in the provisioner API.

Partial PUT behavior:
* Omitted field -> keep existing groups.
* Empty array (`[]`) -> clear all exclusions.
* Non-empty array -> overwrite group list.

Invalid, duplicate, or oversized group lists fail atomically — no partial updates are applied to the active intercept.

## Packet Processing

Prefix filtering is backed by immutable IPv4 and IPv6 Patricia tries.

To keep overhead minimal, source and destination IP lookups are performed once per packet during standard IP CC processing. The resulting group mask is then checked against the policy of each matching intercept.

This flow is shared across standard IP CC and vendor decapsulation paths:
* JMirror
* ALU shim
* Cisco mirror

Malformed packets that fail IPv4/IPv6 parsing fall back to fail-open behavior and proceed down the standard CC path.

Suppressed records are dropped early — before export job allocation, packet copying, ZMQ pub, or sequence tracking.

## Persistence & Runtime Updates

* Group definitions are stored in the provisioner YAML config and restored on startup
* Mask updates dynamically propagate to active dynamic sessions (v4/v6), static IP sessions, and vendor mirror intercepts without requiring a collector restart.

## Testing

**Verified in lab / local testbed:**
* Core provisioner flows (POST, GET, partial PUT, persistence across restarts).
* Validation logic (duplicate group rejection, failed PUT transaction safety).
* Dynamic enable/disable on live sessions (no restart needed).
* IPv4 dynamic IP CC filtering.
* Intercept isolation (verified per-LIID filtering with two overlapping intercepts for the same target).
* Output capture validation (pcapdisk, agency delivery, JMirror).
* Performance benchmarking on JMirror (no measurable throughput regression observed with single-prefix filtering active).

**Implemented and build-verified (pending traffic testing in live environment):**
* IPv6 prefix matching.
* Static IP intercept ranges.
* ALU shim and Cisco mirror decapsulation paths.

Note: Code analyzed and prepared with assistance from GPT-5.6. Reviewed and tested manually.