### PR TITLE
Liid authcc uniquenessKey internal intercept state by authCC + LIID

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,7 +22,7 @@ In no particular order, we would like to thank the following people:
  * NETPLANET GmbH for contributing code to support the "sipusesessiondir"
    configuration option (AT-specific requirement)
  * Pawel Jablonski for contributing a number of performance improvements.
- * Jason van der Schyff for contributing bug fixes to our TLS integration.
+ * Jason Van der Schyff for contributing bug fixes to our TLS integration.
  * Laura Domínguez Céspedes for adding support for PQC TLS.
 
 Apologies to anyone that has made a contribution but we've forgotten to

--- a/doc/MediatorDoc.md
+++ b/doc/MediatorDoc.md
@@ -57,7 +57,10 @@ any intercepts, you will need to set the pcap directory option in your
 mediator configuration. All pcap traces created by this mediator will be
 written into this directory; by default, the filenames for the pcap traces
 will include the LIID for the intercept so should be unique and easily
-identifiable.
+identifiable. Note that LIIDs are only required to be unique within an
+authorising country -- if two pcap-output intercepts from different
+authorising countries share an LIID, their packets will be written into the
+same output files (and a warning will be logged by the mediator).
 
 The pcap output files will be rotated every 30 minutes. If no traffic is
 observed for that intercept during the 30 minute period, no output file will

--- a/doc/ProvisionerDoc.md
+++ b/doc/ProvisionerDoc.md
@@ -156,8 +156,11 @@ All VOIP (or IPMM, to use ETSI terminology) intercepts are specified using the
 voipintercepts option. Each intercept is expressed as an item in a list and
 each intercept must be configured with the following six parameters:
 
-* LIID -- the unique lawful intercept ID for this intercept. This will be
-  assigned by the agency and should be present on the warrant for the intercept.
+* LIID -- the lawful intercept ID for this intercept. This will be
+  assigned by the agency and should be present on the warrant for the
+  intercept. An LIID only needs to be unique within its authorising country;
+  two intercepts may share an LIID provided their authorisation country codes
+  differ.
 * Authorisation country code -- the country within which the authorisation to
   intercept was granted.
 * Delivery country code -- the country where the intercept is taking place
@@ -183,8 +186,11 @@ All email intercepts are specified using the emailintercepts option.
 Each intercept is expressed as an item in a list and each intercept must be
 configured with the following six parameters:
 
-* LIID -- the unique lawful intercept ID for this intercept. This will be
-  assigned by the agency and should be present on the warrant for the intercept.
+* LIID -- the lawful intercept ID for this intercept. This will be
+  assigned by the agency and should be present on the warrant for the
+  intercept. An LIID only needs to be unique within its authorising country;
+  two intercepts may share an LIID provided their authorisation country codes
+  differ.
 * Authorisation country code -- the country within which the authorisation to
   intercept was granted.
 * Delivery country code -- the country where the intercept is taking place
@@ -206,8 +212,11 @@ All IP intercepts are specified using the ipintercepts option. As with VOIP
 intercepts, each individual intercept is expressed as a list item and each
 intercept must be configured with the following parameters:
 
-* LIID -- the unique lawful intercept ID for this intercept. This will be
-  assigned by the agency and should be present on the warrant for the intercept.
+* LIID -- the lawful intercept ID for this intercept. This will be
+  assigned by the agency and should be present on the warrant for the
+  intercept. An LIID only needs to be unique within its authorising country;
+  two intercepts may share an LIID provided their authorisation country codes
+  differ.
 * Authorisation country code -- the country within which the authorisation to
   intercept was granted.
 * Delivery country code -- the country where the intercept is taking place

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -165,4 +165,16 @@ openlimediator_LDFLAGS=-lpthread @MEDIATOR_LIBS@
 openlimediator_CFLAGS=-I$(abs_top_srcdir)/extlib/libpatricia/ -Icollector/etsiencoding -I$(builddir) -Werror -Wall -Wextra
 endif
 
+check_PROGRAMS = test_intercept_liid_key
+TESTS = $(check_PROGRAMS)
+
+test_intercept_liid_key_SOURCES = tests/test_intercept_liid_key.c \
+                intercept.c intercept.h util.c util.h logger.c logger.h \
+                byteswap.c byteswap.h collector/jenkinshash.c \
+                configparser_common.c configparser_common.h \
+                coreserver.c coreserver.h
+test_intercept_liid_key_LDADD = @ADD_LIBS@
+test_intercept_liid_key_LDFLAGS = -lpthread @PROVISIONER_LIBS@
+test_intercept_liid_key_CFLAGS = -Werror -Wall -Wextra
+
 install-exec-hook: $(INSTALL_EXEC_HOOKS)

--- a/src/collector/collector_base.h
+++ b/src/collector/collector_base.h
@@ -149,6 +149,7 @@ typedef struct colsync_udp_sink {
     char *sourceport;
 
     char *attached_liid;
+    char *attached_authcc;
     pthread_t tid;
 
     void *zmq_control;
@@ -373,6 +374,7 @@ typedef struct shared_liid_to_agency_mapping {
 
 typedef struct encoder_liid_state {
     char *liid_key;
+    char *liid;
     char *authcc;
     char *delivcc;
     uint8_t no_agency_map_warning;
@@ -396,6 +398,7 @@ struct integrity_check_state {
 
     char *key;
     char *liid_key;
+    char *liid;
     char *authcc;
     char *delivcc;
     char *cinstr;

--- a/src/collector/collector_integrity_check.c
+++ b/src/collector/collector_integrity_check.c
@@ -222,8 +222,8 @@ static inline void populate_integrity_check_pshdr_data(
         wandder_etsipshdr_data_t *hdrdata, integrity_check_state_t *ics,
         char *netelemid, char *operatorid) {
 
-    hdrdata->liid = ics->liid_key;
-    hdrdata->liid_len = strlen(ics->liid_key);
+    hdrdata->liid = ics->liid;
+    hdrdata->liid_len = strlen(ics->liid);
     hdrdata->liid_format = ics->liid_format;
     hdrdata->authcc = ics->authcc;
     hdrdata->delivcc = ics->delivcc;
@@ -319,6 +319,7 @@ uint8_t update_integrity_check_state(integrity_check_state_t **map,
         found->cin = cin;
         found->msgtype = msgtype;
         found->liid_key = strdup(known->liid_key);
+        found->liid = strdup(known->liid);
         found->authcc = strdup(known->authcc);
         found->delivcc = strdup(known->delivcc);
         found->hashed_seqnos = calloc(32, sizeof(int64_t));
@@ -679,6 +680,7 @@ void free_integrity_check_state(integrity_check_state_t *integ) {
 
     if (integ->key) free(integ->key);
     if (integ->liid_key) free(integ->liid_key);
+    if (integ->liid) free(integ->liid);
     if (integ->authcc) free(integ->authcc);
     if (integ->delivcc) free(integ->delivcc);
     if (integ->cinstr) free(integ->cinstr);

--- a/src/collector/collector_publish.c
+++ b/src/collector/collector_publish.c
@@ -278,6 +278,9 @@ void free_published_message(openli_export_recv_t *msg) {
         if (msg->data.cininfo.liid) {
             free(msg->data.cininfo.liid);
         }
+        if (msg->data.cininfo.authcc) {
+            free(msg->data.cininfo.authcc);
+        }
     }
 
     free(msg);

--- a/src/collector/collector_publish.h
+++ b/src/collector/collector_publish.h
@@ -220,6 +220,7 @@ typedef struct openli_rawip_job {
 
 typedef struct openli_cin_info_job {
     char *liid;
+    char *authcc;
     uint32_t cin;
 } openli_cin_info_job_t;
 

--- a/src/collector/collector_push_messaging.c
+++ b/src/collector/collector_push_messaging.c
@@ -118,14 +118,14 @@ int add_iprange_to_patricia(patricia_tree_t *ptree, char *iprangestr,
         prefix->ref_count --;
     }
 
-    HASH_FIND(hh, *all, common->liid, common->liid_len, found);
+    HASH_FIND(hh, *all, common->liid_key, common->liid_key_len, found);
     if (found) {
         return 0;
     } else {
         char key[128];
 
         found = (liid_set_t *)malloc(sizeof(liid_set_t));
-        found->liid = strdup(common->liid);
+        found->liid = strdup(common->liid_key);
         found->cin = cin;
 
         snprintf(key, 127, "%s-%u", found->liid, found->cin);
@@ -169,7 +169,7 @@ void remove_iprange_from_patricia(patricia_tree_t *ptree, char *iprangestr,
     }
 
     all = (liid_set_t **)&(node->data);
-    HASH_FIND(hh, *all, common->liid, common->liid_len, found);
+    HASH_FIND(hh, *all, common->liid_key, common->liid_key_len, found);
     if (!found) {
         logger(LOG_INFO,
                 "OpenLI: supposed to remove IP prefix %s for LIID %s but the LIID is not associated with that prefix.",
@@ -446,11 +446,11 @@ void handle_push_mirror_intercept(colthread_local_t *loc,
                 sizeof(vmi->sessionid), vmilist);
     }
 
-    HASH_FIND(hh, vmilist->intercepts, vmi->common.liid, (vmi->common.liid_len),
-            found);
+    HASH_FIND(hh, vmilist->intercepts, vmi->common.liid_key,
+            vmi->common.liid_key_len, found);
     if (!found) {
-        HASH_ADD_KEYPTR(hh, vmilist->intercepts, vmi->common.liid,
-                vmi->common.liid_len, vmi);
+        HASH_ADD_KEYPTR(hh, vmilist->intercepts, vmi->common.liid_key,
+                vmi->common.liid_key_len, vmi);
     } else {
         logger(LOG_INFO, "OpenLI: collector received duplicate vendmirror intercept %u:%s, ignoring.", vmi->sessionid, vmi->common.liid);
         free_single_vendmirror_intercept(vmi);
@@ -472,8 +472,8 @@ void handle_halt_mirror_intercept(colthread_local_t *loc,
         return;
     }
 
-    HASH_FIND(hh, parent->intercepts, vmi->common.liid, vmi->common.liid_len,
-            found);
+    HASH_FIND(hh, parent->intercepts, vmi->common.liid_key,
+            vmi->common.liid_key_len, found);
     if (found == NULL) {
         logger(LOG_INFO, "OpenLI: collector thread was unable to remove JMirror intercept %u:%s, as the LIID was not present in its intercept list.",
                 vmi->sessionid, vmi->common.liid);
@@ -684,7 +684,7 @@ void handle_modify_iprange(colthread_local_t *loc, staticipsession_t *ipr) {
     }
 
     all = (liid_set_t **)&(node->data);
-    HASH_FIND(hh, *all, ipr->common.liid, ipr->common.liid_len, found);
+    HASH_FIND(hh, *all, ipr->common.liid_key, ipr->common.liid_key_len, found);
     if (!found) {
         logger(LOG_INFO,
                 "OpenLI: processing thread was supposed to modify IP prefix %s for LIID %s but the LIID is not associated with that prefix.",
@@ -803,7 +803,7 @@ void handle_change_vendmirror_intercept(colthread_local_t *loc,
         return;
     }
 
-    HASH_FIND(hh, parent->intercepts, vend->common.liid, vend->common.liid_len,
+    HASH_FIND(hh, parent->intercepts, vend->common.liid_key, vend->common.liid_key_len,
             found);
     if (found == NULL) {
         logger(LOG_INFO, "OpenLI: collector thread was unable to modify Vendor Mirror intercept %u:%s, as the LIID was not present in its intercept list.",

--- a/src/collector/collector_seqtracker.c
+++ b/src/collector/collector_seqtracker.c
@@ -47,6 +47,9 @@ static inline void free_intercept_msg(exporter_intercept_msg_t *msg) {
     if (msg->liid) {
         free(msg->liid);
     }
+    if (msg->liid_key) {
+        free(msg->liid_key);
+    }
     if (msg->authcc) {
         free(msg->authcc);
     }
@@ -330,10 +333,11 @@ static void track_new_intercept(seqtracker_thread_data_t *seqdata,
         published_intercept_msg_t *cept) {
 
     exporter_intercept_state_t *intstate;
+    char liid_key[2048];
 
-    /* If this LIID already exists, we'll need to replace it */
-    HASH_FIND(hh, seqdata->intercepts, cept->liid, strlen(cept->liid),
-			intstate);
+    /* If this intercept already exists, we'll need to replace it */
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", cept->authcc, cept->liid);
+    HASH_FIND(hh, seqdata->intercepts, liid_key, strlen(liid_key), intstate);
 
     if (intstate) {
         remove_preencoded(seqdata, intstate);
@@ -348,11 +352,13 @@ static void track_new_intercept(seqtracker_thread_data_t *seqdata,
         intstate->version ++;
 
     } else {
-        /* New LIID, create fresh intercept state */
+        /* New intercept, create fresh intercept state */
         intstate = (exporter_intercept_state_t *)malloc(
                 sizeof(exporter_intercept_state_t));
         intstate->details.liid = strdup(cept->liid);
         intstate->details.liid_len = strlen(cept->liid);
+        intstate->details.liid_key = strdup(liid_key);
+        intstate->details.liid_key_len = strlen(liid_key);
         intstate->cinsequencing = NULL;
         intstate->version = 0;
         intstate->encoder_index = seqdata->rr_next_encoder_assign;
@@ -360,8 +366,8 @@ static void track_new_intercept(seqtracker_thread_data_t *seqdata,
         if (seqdata->rr_next_encoder_assign >= seqdata->encoders) {
             seqdata->rr_next_encoder_assign %= seqdata->encoders;
         }
-        HASH_ADD_KEYPTR(hh, seqdata->intercepts, intstate->details.liid,
-                intstate->details.liid_len, intstate);
+        HASH_ADD_KEYPTR(hh, seqdata->intercepts, intstate->details.liid_key,
+                intstate->details.liid_key_len, intstate);
     }
 
     intstate->details.agencyid = strdup(cept->targetagency);
@@ -429,7 +435,10 @@ static int modify_tracked_intercept(seqtracker_thread_data_t *seqdata,
 
     int unused;
     exporter_intercept_state_t *intstate;
-    HASH_FIND(hh, seqdata->intercepts, msg->liid, strlen(msg->liid), intstate);
+    char liid_key[2048];
+
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", msg->authcc, msg->liid);
+    HASH_FIND(hh, seqdata->intercepts, liid_key, strlen(liid_key), intstate);
 
     if (!intstate) {
         logger(LOG_INFO, "OpenLI collector: tracker thread was told to modify intercept LIID %s, but it is not a valid ID?",
@@ -479,8 +488,10 @@ static int remove_tracked_intercept(seqtracker_thread_data_t *seqdata,
     size_t index;
     int ret = 1;
     openli_encoding_job_t job;
+    char liid_key[2048];
 
-    HASH_FIND(hh, seqdata->intercepts, msg->liid, strlen(msg->liid), intstate);
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", msg->authcc, msg->liid);
+    HASH_FIND(hh, seqdata->intercepts, liid_key, strlen(liid_key), intstate);
 
     if (!intstate) {
         logger(LOG_INFO, "OpenLI collector: tracker thread was told to end intercept LIID %s, but it is not a valid ID?",
@@ -492,6 +503,7 @@ static int remove_tracked_intercept(seqtracker_thread_data_t *seqdata,
      * origreq */
     memset(&job, 0, sizeof(openli_encoding_job_t));
 	job.liid = strdup(msg->liid);
+    job.authcc = strdup(msg->authcc);
 
     index = intstate->encoder_index;
     while (1) {
@@ -509,7 +521,7 @@ static int remove_tracked_intercept(seqtracker_thread_data_t *seqdata,
     }
 
     establish_cinstate_dbconn(seqdata);
-    cinstate_db_remove_by_liid(seqdata->cinstatedb, msg->liid);
+    cinstate_db_remove_by_liid(seqdata->cinstatedb, liid_key);
 
     HASH_DELETE(hh, seqdata->intercepts, intstate);
     free_intercept_state(seqdata, intstate);
@@ -529,6 +541,7 @@ static int generate_encoding_job(seqtracker_thread_data_t *seqdata,
 	job.preencoded = intstate->preencoded;
 	job.origreq = recvd;
 	job.liid = strdup(liid);
+    job.liid_key = strdup(intstate->details.liid_key);
     job.authcc = strdup(authcc);
     job.cinstr = strdup(cinseq->cin_string);
     job.cin = (int64_t)cinseq->cin;
@@ -639,6 +652,7 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
         openli_export_recv_t *recvd) {
 
     char *liid, *authcc, *delivcc;
+    char liid_key[2048];
     uint32_t cin;
     cin_seqno_t *cinseq;
     exporter_intercept_state_t *intstate;
@@ -655,7 +669,8 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
     cin = extract_cin_from_job(recvd);
     iritype = extract_iritype_from_job(recvd);
 
-    HASH_FIND(hh, seqdata->intercepts, liid, strlen(liid), intstate);
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", authcc, liid);
+    HASH_FIND(hh, seqdata->intercepts, liid_key, strlen(liid_key), intstate);
     if (!intstate) {
         logger(LOG_INFO, "Received encoding job for an unknown LIID: %s??",
                 liid);
@@ -665,7 +680,7 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
 
     HASH_FIND(hh, intstate->cinsequencing, &cin, sizeof(cin), cinseq);
     if (!cinseq) {
-        char cinstr[1024];
+        char cinstr[sizeof(liid_key) + 16];
         struct cinstate_t init_cinstate;
 
         establish_cinstate_dbconn(seqdata);
@@ -677,11 +692,12 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
             return -1;
         }
 
-        snprintf(cinstr, 1024, "%s-%u", liid, cin);
+        snprintf(cinstr, sizeof(cinstr), "%s-%u", liid_key, cin);
 
         memset(&init_cinstate, 0, sizeof(init_cinstate));
         if (seqdata->cinstatedb) {
-            cinstate_db_lookup(seqdata->cinstatedb, liid, cin, &init_cinstate);
+            cinstate_db_lookup(seqdata->cinstatedb, liid_key, cin,
+                    &init_cinstate);
         }
 
         cinseq->cin = cin;
@@ -700,6 +716,7 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
             resetjob->type = OPENLI_EXPORT_CIN_RESET;
             resetjob->destid = recvd->destid;
             resetjob->data.cininfo.liid = strdup(liid);
+            resetjob->data.cininfo.authcc = strdup(authcc);
             resetjob->data.cininfo.cin = cin;
 
             generate_encoding_job(seqdata, resetjob, intstate, cinseq,
@@ -759,7 +776,7 @@ static int run_encoding_job(seqtracker_thread_data_t *seqdata,
                 // If we've sent IRI end, we should probably remove this
                 // entry from the cinstate DB because a CIN Reset is
                 // going to be meaningless and/or alarmist
-                cinstate_db_remove_by_cin(seqdata->cinstatedb, liid, cin);
+                cinstate_db_remove_by_cin(seqdata->cinstatedb, liid_key, cin);
             }
         }
         seqno = &(cinseq->iri_seqno);
@@ -776,7 +793,7 @@ postencodepush:
         update_cinstate.cc_seqno = cinseq->cc_seqno;
 
         if (seqdata->cinstate_enabled) {
-            if (cinstate_db_update(seqdata->cinstatedb, liid, cin,
+            if (cinstate_db_update(seqdata->cinstatedb, liid_key, cin,
                     &update_cinstate) < 0) {
                 seqdata->cinstate_enabled = 0;
                 cinstate_db_close(&(seqdata->cinstatedb));
@@ -841,8 +858,14 @@ static void seqtracker_main(seqtracker_thread_data_t *seqdata) {
                     // a worker has determined that a CIN is no longer
                     // active for a session where an IRI End is not suitable
                     // e.g. SIP REGISTER exchanges
-                    cinstate_db_remove_by_cin(seqdata->cinstatedb,
-                            job->data.cininfo.liid, job->data.cininfo.cin);
+                    {
+                        char closekey[2048];
+                        snprintf(closekey, sizeof(closekey), "%s-%s",
+                                job->data.cininfo.authcc,
+                                job->data.cininfo.liid);
+                        cinstate_db_remove_by_cin(seqdata->cinstatedb,
+                                closekey, job->data.cininfo.cin);
+                    }
                     free_published_message(job);
                     break;
 

--- a/src/collector/collector_sync.c
+++ b/src/collector/collector_sync.c
@@ -188,6 +188,9 @@ void destroy_colsync_udp_sink(colsync_udp_sink_t *sink) {
     if (sink->attached_liid) {
         free(sink->attached_liid);
     }
+    if (sink->attached_authcc) {
+        free(sink->attached_authcc);
+    }
     if (sink->key) {
         free(sink->key);
     }
@@ -368,6 +371,20 @@ void clean_sync_data(collector_sync_t *sync) {
 
 }
 
+static ipintercept_t *find_ipintercept_by_liid_authcc(collector_sync_t *sync,
+        char *liid, char *authcc) {
+
+    ipintercept_t *ipint;
+    char key[2048];
+
+    if (liid == NULL || authcc == NULL) {
+        return NULL;
+    }
+    snprintf(key, sizeof(key), "%s-%s", authcc, liid);
+    HASH_FIND(hh_liid, sync->ipintercepts, key, strlen(key), ipint);
+    return ipint;
+}
+
 static void create_unused_udpsink_mapping_from_sink(collector_sync_t *sync,
         colsync_udp_sink_t *sink) {
 
@@ -400,6 +417,7 @@ static void create_unused_udpsink_mapping_from_sink(collector_sync_t *sync,
     config->encapfmt = sink->encapfmt;
     config->cin = sink->cin;
     config->liid = strdup(sink->attached_liid);
+    config->authcc = strdup(sink->attached_authcc);
 
     map = calloc(1, sizeof(saved_udpsink_mapping_t));
     map->config = config;
@@ -422,11 +440,14 @@ static void halt_udp_sink_thread(colsync_udp_sink_t *sink) {
     msg = calloc(1, sizeof(openli_export_recv_t));
     msg->type = OPENLI_EXPORT_INTERCEPT_OVER;
     msg->data.cept.liid = strdup(sink->attached_liid);
+    msg->data.cept.authcc = strdup(sink->attached_authcc);
     msg->data.cept.cepttype = OPENLI_INTERCEPT_TYPE_IP;
     publish_openli_msg(sink->zmq_control, msg);
 
     free(sink->attached_liid);
     sink->attached_liid = NULL;
+    free(sink->attached_authcc);
+    sink->attached_authcc = NULL;
 
     zmq_close(sink->zmq_control);
     sink->zmq_control = NULL;
@@ -443,8 +464,8 @@ static int create_udp_sink_thread(collector_sync_t *sync,
     struct timeval tv;
     openli_export_recv_t *msg;
 
-    HASH_FIND(hh_liid, sync->ipintercepts, config->liid, strlen(config->liid),
-            ipint);
+    ipint = find_ipintercept_by_liid_authcc(sync, config->liid,
+            config->authcc);
     if (!ipint) {
         if (sync->instruct_log) {
             logger(LOG_INFO, "OpenLI: received UDP sink configuration for LIID %s, but this LIID is unknown?", config->liid);
@@ -476,6 +497,7 @@ static int create_udp_sink_thread(collector_sync_t *sync,
     }
 
     sink->attached_liid = strdup(config->liid);
+    sink->attached_authcc = strdup(config->authcc);
     sink->cin = config->cin;
     sink->encapfmt = config->encapfmt;
     sink->direction = config->direction;
@@ -733,8 +755,8 @@ void sync_thread_publish_reload(collector_sync_t *sync) {
                 // it gets reconfigured later on
                 create_unused_udpsink_mapping_from_sink(sync, sink);
 
-                HASH_FIND(hh_liid, sync->ipintercepts, sink->attached_liid,
-                        strlen(sink->attached_liid), ipint);
+                ipint = find_ipintercept_by_liid_authcc(sync,
+                        sink->attached_liid, sink->attached_authcc);
                 if (ipint) {
                     create_ipiri_job_from_vendor(sync, ipint, sink->cin,
                            OPENLI_IPIRI_ENDWHILEACTIVE);
@@ -1350,7 +1372,7 @@ static int new_staticiprange(collector_sync_t *sync, uint8_t *intmsg,
         return -1;
     }
 
-    HASH_FIND(hh_liid, sync->ipintercepts, ipr->liid, strlen(ipr->liid), ipint);
+    ipint = find_ipintercept_by_liid_authcc(sync, ipr->liid, ipr->authcc);
     if (!ipint) {
         if (sync->instruct_log) {
             logger(LOG_INFO,
@@ -1406,7 +1428,7 @@ static int modify_staticiprange(collector_sync_t *sync, static_ipranges_t *ipr)
     sync_sendq_t *tmp, *sendq;
 
 
-    HASH_FIND(hh_liid, sync->ipintercepts, ipr->liid, strlen(ipr->liid), ipint);
+    ipint = find_ipintercept_by_liid_authcc(sync, ipr->liid, ipr->authcc);
     if (!ipint) {
         if (sync->instruct_log) {
             logger(LOG_INFO,
@@ -1464,7 +1486,7 @@ static int remove_staticiprange(collector_sync_t *sync, static_ipranges_t *ipr)
     sync_sendq_t *tmp, *sendq;
 
 
-    HASH_FIND(hh_liid, sync->ipintercepts, ipr->liid, strlen(ipr->liid), ipint);
+    ipint = find_ipintercept_by_liid_authcc(sync, ipr->liid, ipr->authcc);
     if (!ipint) {
         if (sync->instruct_log) {
             logger(LOG_INFO,
@@ -1820,7 +1842,7 @@ static void update_liid_mapping_from_email_intercept(collector_sync_t *sync,
         }
         pthread_rwlock_wrlock(sync->liid_agency_mutex);
         remove_liid_to_agency_map_entry(&(sync->liid_agency_map->map),
-                decode->common.liid);
+                decode->common.liid_key);
         pthread_rwlock_unlock(sync->liid_agency_mutex);
     } else if (msgtype == OPENLI_PROTO_MODIFY_EMAILINTERCEPT) {
         if (decode_emailintercept_modify(provmsg, msglen, decode) < 0) {
@@ -1829,7 +1851,7 @@ static void update_liid_mapping_from_email_intercept(collector_sync_t *sync,
         }
         pthread_rwlock_wrlock(sync->liid_agency_mutex);
         update_liid_to_agency_map(&(sync->liid_agency_map->map),
-                decode->common.liid, decode->common.targetagency);
+                decode->common.liid_key, decode->common.targetagency);
         pthread_rwlock_unlock(sync->liid_agency_mutex);
     } else if (msgtype == OPENLI_PROTO_START_EMAILINTERCEPT) {
         if (decode_emailintercept_start(provmsg, msglen, decode) < 0) {
@@ -1838,7 +1860,7 @@ static void update_liid_mapping_from_email_intercept(collector_sync_t *sync,
         }
         pthread_rwlock_wrlock(sync->liid_agency_mutex);
         update_liid_to_agency_map(&(sync->liid_agency_map->map),
-                decode->common.liid, decode->common.targetagency);
+                decode->common.liid_key, decode->common.targetagency);
         pthread_rwlock_unlock(sync->liid_agency_mutex);
 
     }
@@ -1869,7 +1891,7 @@ static int x2x3_sync_voipintercept(collector_sync_t *sync, uint8_t *provmsg,
         }
         pthread_rwlock_wrlock(sync->liid_agency_mutex);
         remove_liid_to_agency_map_entry(&(sync->liid_agency_map->map),
-                decode->common.liid);
+                decode->common.liid_key);
         pthread_rwlock_unlock(sync->liid_agency_mutex);
     } else if (msgtype == OPENLI_PROTO_MODIFY_VOIPINTERCEPT) {
         if (decode_voipintercept_modify(provmsg, msglen, decode) < 0) {
@@ -1878,7 +1900,7 @@ static int x2x3_sync_voipintercept(collector_sync_t *sync, uint8_t *provmsg,
         }
         pthread_rwlock_wrlock(sync->liid_agency_mutex);
         update_liid_to_agency_map(&(sync->liid_agency_map->map),
-                decode->common.liid, decode->common.targetagency);
+                decode->common.liid_key, decode->common.targetagency);
         pthread_rwlock_unlock(sync->liid_agency_mutex);
 
     } else {
@@ -1888,7 +1910,7 @@ static int x2x3_sync_voipintercept(collector_sync_t *sync, uint8_t *provmsg,
         }
         pthread_rwlock_wrlock(sync->liid_agency_mutex);
         update_liid_to_agency_map(&(sync->liid_agency_map->map),
-                decode->common.liid, decode->common.targetagency);
+                decode->common.liid_key, decode->common.targetagency);
         pthread_rwlock_unlock(sync->liid_agency_mutex);
     }
 
@@ -1969,7 +1991,7 @@ static int insert_new_ipintercept(collector_sync_t *sync, ipintercept_t *cept) {
     if (sync->pubsockcount <= 1) {
         cept->common.seqtrackerid = 0;
     } else {
-        cept->common.seqtrackerid = hash_liid(cept->common.liid) % sync->pubsockcount;
+        cept->common.seqtrackerid = hash_liid(cept->common.liid_key) % sync->pubsockcount;
     }
 
     if (cept->vendmirrorid != OPENLI_VENDOR_MIRROR_NONE) {
@@ -1994,8 +2016,8 @@ static int insert_new_ipintercept(collector_sync_t *sync, ipintercept_t *cept) {
                 cept->common.tostart_time, cept->common.toend_time);
     }
 
-    HASH_ADD_KEYPTR(hh_liid, sync->ipintercepts, cept->common.liid,
-            cept->common.liid_len, cept);
+    HASH_ADD_KEYPTR(hh_liid, sync->ipintercepts, cept->common.liid_key,
+            cept->common.liid_key_len, cept);
 
     add_new_intercept_time_event(&(sync->upcoming_intercept_events), cept,
             &(cept->common));
@@ -2006,8 +2028,8 @@ static int insert_new_ipintercept(collector_sync_t *sync, ipintercept_t *cept) {
     pthread_mutex_unlock(sync->glob->stats_mutex);
 
     pthread_rwlock_wrlock(sync->liid_agency_mutex);
-    update_liid_to_agency_map(&(sync->liid_agency_map->map), cept->common.liid,
-            cept->common.targetagency);
+    update_liid_to_agency_map(&(sync->liid_agency_map->map),
+            cept->common.liid_key, cept->common.targetagency);
     pthread_rwlock_unlock(sync->liid_agency_mutex);
 
     expmsg = create_intercept_details_msg(&(cept->common),
@@ -2083,7 +2105,8 @@ static void remove_ip_intercept(collector_sync_t *sync, ipintercept_t *ipint) {
         if (sink->attached_liid == NULL) {
             continue;
         }
-        if (strcmp(sink->attached_liid, ipint->common.liid) == 0) {
+        if (strcmp(sink->attached_liid, ipint->common.liid) == 0 &&
+                strcmp(sink->attached_authcc, ipint->common.authcc) == 0) {
             // send an IRI END
             create_ipiri_job_from_vendor(sync, ipint, sink->cin,
                    OPENLI_IPIRI_ENDWHILEACTIVE);
@@ -2094,7 +2117,7 @@ static void remove_ip_intercept(collector_sync_t *sync, ipintercept_t *ipint) {
 
     pthread_rwlock_wrlock(sync->liid_agency_mutex);
     remove_liid_to_agency_map_entry(&(sync->liid_agency_map->map),
-            ipint->common.liid);
+            ipint->common.liid_key);
     pthread_rwlock_unlock(sync->liid_agency_mutex);
 
     withdraw_xid(sync, ipint);
@@ -2157,8 +2180,8 @@ static int update_modified_intercept(collector_sync_t *sync,
             &(modified->common), OPENLI_INTERCEPT_TYPE_IP, &changed);
 
     pthread_rwlock_wrlock(sync->liid_agency_mutex);
-    update_liid_to_agency_map(&(sync->liid_agency_map->map), ipint->common.liid,
-            ipint->common.targetagency);
+    update_liid_to_agency_map(&(sync->liid_agency_map->map),
+            ipint->common.liid_key, ipint->common.targetagency);
     pthread_rwlock_unlock(sync->liid_agency_mutex);
 
     if (ipint->accesstype != modified->accesstype) {
@@ -2187,7 +2210,8 @@ static int update_modified_intercept(collector_sync_t *sync,
         pthread_mutex_lock(&(sync->glob->mutex));
         HASH_ITER(hh, sync->glob->udpsinks, sink, tmpsink) {
             if (sink->attached_liid &&
-                    strcmp(ipint->common.liid, sink->attached_liid) == 0) {
+                    strcmp(ipint->common.liid, sink->attached_liid) == 0 &&
+                    strcmp(ipint->common.authcc, sink->attached_authcc) == 0) {
                 expmsg = create_intercept_details_msg(&(modified->common),
                         OPENLI_INTERCEPT_TYPE_IP);
                 expmsg->type = OPENLI_EXPORT_INTERCEPT_CHANGED;
@@ -2219,8 +2243,8 @@ static int modify_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
         return -1;
     }
 
-    HASH_FIND(hh_liid, sync->ipintercepts, modified->common.liid,
-            modified->common.liid_len, ipint);
+    HASH_FIND(hh_liid, sync->ipintercepts, modified->common.liid_key,
+            modified->common.liid_key_len, ipint);
 
     if (!ipint) {
         return insert_new_ipintercept(sync, modified);
@@ -2245,8 +2269,8 @@ static int halt_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
         return -1;
     }
 
-    HASH_FIND(hh_liid, sync->ipintercepts, torem->common.liid,
-            torem->common.liid_len, ipint);
+    HASH_FIND(hh_liid, sync->ipintercepts, torem->common.liid_key,
+            torem->common.liid_key_len, ipint);
 
     if (!ipint) {
         logger(LOG_INFO,
@@ -2461,8 +2485,8 @@ static int withdraw_collector_udp_sink(collector_sync_t *sync, uint8_t *provmsg,
         if (sink->attached_liid) {
             ipintercept_t *ipint;
             create_unused_udpsink_mapping_from_sink(sync, sink);
-            HASH_FIND(hh_liid, sync->ipintercepts, sink->attached_liid,
-                    strlen(sink->attached_liid), ipint);
+            ipint = find_ipintercept_by_liid_authcc(sync, sink->attached_liid,
+                    sink->attached_authcc);
             if (ipint) {
                 create_ipiri_job_from_vendor(sync, ipint, sink->cin,
                         OPENLI_IPIRI_ENDWHILEACTIVE);
@@ -2722,8 +2746,8 @@ static int new_ipintercept(collector_sync_t *sync, uint8_t *intmsg,
     }
 
     /* Check if we already have this intercept */
-    HASH_FIND(hh_liid, sync->ipintercepts, cept->common.liid,
-            cept->common.liid_len, x);
+    HASH_FIND(hh_liid, sync->ipintercepts, cept->common.liid_key,
+            cept->common.liid_key_len, x);
 
     if (x) {
         /* Duplicate LIID */

--- a/src/collector/email_worker.c
+++ b/src/collector/email_worker.c
@@ -723,8 +723,8 @@ static void start_email_intercept(openli_email_worker_t *state,
         em->common.seqtrackerid = hash_liid(em->common.liid) % state->tracker_threads;
     }
 
-    HASH_ADD_KEYPTR(hh_liid, state->allintercepts, em->common.liid,
-            em->common.liid_len, em);
+    HASH_ADD_KEYPTR(hh_liid, state->allintercepts, em->common.liid_key,
+            em->common.liid_key_len, em);
 
     if (addtargets) {
         HASH_ITER(hh, em->targets, tgt, tmp) {
@@ -905,8 +905,8 @@ static int add_new_email_intercept(openli_email_worker_t *state,
         return -1;
     }
 
-    HASH_FIND(hh_liid, state->allintercepts, em->common.liid,
-            em->common.liid_len, found);
+    HASH_FIND(hh_liid, state->allintercepts, em->common.liid_key,
+            em->common.liid_key_len, found);
 
     if (found) {
         email_target_t *tgt, *tmp;
@@ -949,8 +949,8 @@ static int modify_email_intercept(openli_email_worker_t *state,
         return -1;
     }
 
-    HASH_FIND(hh_liid, state->allintercepts, decode->common.liid,
-            decode->common.liid_len, found);
+    HASH_FIND(hh_liid, state->allintercepts, decode->common.liid_key,
+            decode->common.liid_key_len, found);
     if (!found) {
         start_email_intercept(state, decode, 0);
         return 0;
@@ -972,8 +972,8 @@ static int halt_email_intercept(openli_email_worker_t *state,
         return -1;
     }
 
-    HASH_FIND(hh_liid, state->allintercepts, decode->common.liid,
-            decode->common.liid_len, found);
+    HASH_FIND(hh_liid, state->allintercepts, decode->common.liid_key,
+            decode->common.liid_key_len, found);
     if (!found && state->emailid == 0) {
         logger(LOG_INFO, "OpenLI: tried to halt email intercept %s but this was not in the intercept map?", decode->common.liid);
         free_single_emailintercept(decode);

--- a/src/collector/encoder_worker.c
+++ b/src/collector/encoder_worker.c
@@ -49,6 +49,9 @@ static void destroy_known_liid(encoder_liid_state_t *known) {
     if (known->liid_key) {
         free(known->liid_key);
     }
+    if (known->liid) {
+        free(known->liid);
+    }
     if (known->authcc) {
         free(known->authcc);
     }
@@ -77,6 +80,9 @@ static void destroy_encoding_job(openli_encoding_job_t *job,
     }
     if (job->liid) {
         free(job->liid);
+    }
+    if (job->liid_key) {
+        free(job->liid_key);
     }
     if (job->authcc) {
         free(job->authcc);
@@ -535,9 +541,13 @@ static encoder_liid_state_t *create_new_known_liid(openli_encoder_t *enc,
         char *liid, char *authcc, char *delivcc, char *operatorid) {
 
     encoder_liid_state_t *found;
+    int keylen;
 
     found = calloc(1, sizeof(encoder_liid_state_t));
-    found->liid_key = strdup(liid);
+    keylen = strlen(authcc) + strlen(liid) + 2;
+    found->liid_key = malloc(keylen);
+    snprintf(found->liid_key, keylen, "%s-%s", authcc, liid);
+    found->liid = strdup(liid);
     found->authcc = strdup(authcc);
     if (delivcc) {
         found->delivcc = strdup(delivcc);
@@ -552,9 +562,9 @@ static encoder_liid_state_t *create_new_known_liid(openli_encoder_t *enc,
     }
 
     found->fwd_index = assign_liid_to_forwarder(enc->fwd_assigner);
-        logger(LOG_INFO,
+    logger(LOG_INFO,
             "OpenLI: encoder worker %d assigned LIID %s to forwarding thread %zu",
-            enc->workerid, liid, found->fwd_index);
+            enc->workerid, found->liid_key, found->fwd_index);
 
     HASH_ADD_KEYPTR(hh, enc->known_liids, found->liid_key,
             strlen(found->liid_key), found);
@@ -566,7 +576,7 @@ static int encode_rawip(openli_encoder_t *enc, openli_encoding_job_t *job,
 
     uint16_t liidlen, l;
 
-    liidlen = strlen(job->liid);
+    liidlen = strlen(job->liid_key);
     l = htons(liidlen);
 
     memset(res, 0, sizeof(openli_encoded_result_t));
@@ -576,7 +586,7 @@ static int encode_rawip(openli_encoder_t *enc, openli_encoding_job_t *job,
     res->msgbody->encoded = malloc(liidlen + sizeof(uint16_t));
 
     memcpy(res->msgbody->encoded, &l, sizeof(uint16_t));
-    memcpy(res->msgbody->encoded + sizeof(uint16_t), job->liid, liidlen);
+    memcpy(res->msgbody->encoded + sizeof(uint16_t), job->liid_key, liidlen);
 
     res->msgbody->len = job->origreq->data.rawip.ipclen +
             (liidlen + sizeof(uint16_t));
@@ -638,7 +648,7 @@ static int encode_templated_ipiri(openli_encoder_t *enc,
         }
     } else {
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
-                body->len, NULL, 0, job->origreq->type, job->liid) < 0) {
+                body->len, NULL, 0, job->origreq->type, job->liid_key) < 0) {
             wandder_release_encoded_result(enc->encoder, body);
             free_ipiri_parameters(params);
             return -1;
@@ -685,7 +695,7 @@ static int encode_templated_emailiri(openli_encoder_t *enc,
         }
     } else {
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
-                body->len, NULL, 0, job->origreq->type, job->liid) < 0) {
+                body->len, NULL, 0, job->origreq->type, job->liid_key) < 0) {
             wandder_release_encoded_result(enc->encoder, body);
             return -1;
         }
@@ -754,7 +764,7 @@ static int encode_templated_cinreset(openli_encoder_t *enc,
         }
     } else {
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
-                body->len, NULL, 0, OPENLI_EXPORT_CIN_RESET, job->liid) < 0) {
+                body->len, NULL, 0, OPENLI_EXPORT_CIN_RESET, job->liid_key) < 0) {
             wandder_release_encoded_result(enc->encoder, body);
             return -1;
         }
@@ -795,7 +805,7 @@ static int encode_templated_segflag(openli_encoder_t *enc,
         }
     } else {
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
-                body->len, NULL, 0, restype, job->liid) < 0) {
+                body->len, NULL, 0, restype, job->liid_key) < 0) {
             wandder_release_encoded_result(enc->encoder, body);
             return -1;
         }
@@ -846,7 +856,7 @@ static int encode_templated_epscc(openli_encoder_t *enc,
     } else {
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
                 body->len, epsccjob->ipcontent, epsccjob->ipclen,
-                job->origreq->type, job->liid) < 0) {
+                job->origreq->type, job->liid_key) < 0) {
             wandder_release_encoded_result(enc->encoder, body);
             return -1;
         }
@@ -898,7 +908,7 @@ static int encode_templated_epsiri(openli_encoder_t *enc,
         }
     } else {
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
-                body->len, NULL, 0, job->origreq->type, job->liid) < 0) {
+                body->len, NULL, 0, job->origreq->type, job->liid_key) < 0) {
             wandder_release_encoded_result(enc->encoder, body);
             return -1;
         }
@@ -950,7 +960,7 @@ static int encode_templated_umtsiri(openli_encoder_t *enc,
         }
     } else {
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
-                body->len, NULL, 0, job->origreq->type, job->liid) < 0) {
+                body->len, NULL, 0, job->origreq->type, job->liid_key) < 0) {
             wandder_release_encoded_result(enc->encoder, body);
             return -1;
         }
@@ -1007,7 +1017,7 @@ static int encode_templated_umtscc(openli_encoder_t *enc,
                 umtscc_tplate->cc_content.cc_wrap,
                 umtscc_tplate->cc_content.cc_wrap_len,
                 (uint8_t *)ccjob->ipcontent, ccjob->ipclen,
-                job->origreq->type, job->liid) < 0) {
+                job->origreq->type, job->liid_key) < 0) {
             return -1;
         }
     }
@@ -1088,7 +1098,7 @@ static int encode_templated_emailcc(openli_encoder_t *enc,
                 emailcc_tplate->cc_content.cc_wrap_len,
                 (uint8_t *)emailccjob->cc_content,
                 emailccjob->cc_content_len, job->origreq->type,
-                job->liid) < 0) {
+                job->liid_key) < 0) {
             return -1;
         }
     }
@@ -1141,7 +1151,7 @@ static int encode_templated_ipcc(openli_encoder_t *enc,
                 ipcc_tplate->cc_content.cc_wrap,
                 ipcc_tplate->cc_content.cc_wrap_len,
                 (uint8_t *)ipccjob->ipcontent,
-                ipccjob->ipclen, job->origreq->type, job->liid) < 0) {
+                ipccjob->ipclen, job->origreq->type, job->liid_key) < 0) {
             return -1;
         }
     }
@@ -1297,6 +1307,7 @@ static int process_job(openli_encoder_t *enc, void *socket) {
     size_t next;
     uint8_t fullbatch = 0;
     encoder_liid_state_t *found = NULL;
+    char liid_key[2048];
 
     openli_encoding_job_t job;
 
@@ -1327,11 +1338,12 @@ static int process_job(openli_encoder_t *enc, void *socket) {
             break;
         }
 
-        if (job.liid == NULL) {
+        if (job.liid == NULL || job.authcc == NULL) {
             goto encodejoberror;
         }
 
-        HASH_FIND(hh, enc->known_liids, job.liid, strlen(job.liid), found);
+        snprintf(liid_key, sizeof(liid_key), "%s-%s", job.authcc, job.liid);
+        HASH_FIND(hh, enc->known_liids, liid_key, strlen(liid_key), found);
 
         if (job.origreq == NULL) {
             /* This is a message to tell us that the intercept is no
@@ -1339,9 +1351,9 @@ static int process_job(openli_encoder_t *enc, void *socket) {
             if (found) {
                 integrity_check_state_t *ics, *tmp;
                 HASH_DELETE(hh, enc->known_liids, found);
-                // remove all integrity state chains for this LIID
+                // remove all integrity state chains for this intercept
                 HASH_ITER(hh, enc->integrity_state, ics, tmp) {
-                    if (strcmp(job.liid, ics->liid_key) != 0) {
+                    if (strcmp(liid_key, ics->liid_key) != 0) {
                         continue;
                     }
                     HASH_DELETE(hh, enc->integrity_state, ics);

--- a/src/collector/etsiencoding/encryptcontainer.c
+++ b/src/collector/etsiencoding/encryptcontainer.c
@@ -441,7 +441,7 @@ int create_preencrypted_message_body(wandder_encoder_t *encoder,
     /* We should now have a suitable header template and body template to
      * create a complete ETSI PSPDU record */
     if (create_etsi_encoded_result(res, hdr_tplate, tplate->start,
-            tplate->totallen, NULL, 0, job->origreq->type, job->liid) < 0) {
+            tplate->totallen, NULL, 0, job->origreq->type, job->liid_key) < 0) {
         free(buf);
         return -1;
     }

--- a/src/collector/etsiencoding/etsiencoding.h
+++ b/src/collector/etsiencoding/etsiencoding.h
@@ -137,6 +137,7 @@ typedef struct encoder_job {
     char *cinstr;
     openli_export_recv_t *origreq;
     char *liid;
+    char *liid_key;
     char *authcc;
     char *delivcc;
     uint8_t cept_version;

--- a/src/collector/etsiencoding/ipmmcc.c
+++ b/src/collector/etsiencoding/ipmmcc.c
@@ -319,7 +319,7 @@ int encode_templated_ipmmcc(wandder_encoder_t *encoder,
         if (create_etsi_encoded_result(res, hdr_tplate,
                 ipmmcc_tplate->cc_content.cc_wrap,
                 ipmmcc_tplate->cc_content.cc_wrap_len, NULL, 0,
-                job->origreq->type, job->liid) < 0) {
+                job->origreq->type, job->liid_key) < 0) {
             return -1;
         }
     }

--- a/src/collector/etsiencoding/ipmmiri.c
+++ b/src/collector/etsiencoding/ipmmiri.c
@@ -243,7 +243,7 @@ int encode_templated_ipmmiri(wandder_encoder_t *encoder,
         if (create_etsi_encoded_result(res, hdr_tplate, body->encoded,
                 body->len, NULL, 0,
                 //(uint8_t *)(irijob->content), irijob->contentlen,
-                job->origreq->type, job->liid) < 0) {
+                job->origreq->type, job->liid_key) < 0) {
             wandder_release_encoded_result(encoder, body);
             return -1;
         }

--- a/src/collector/export_shared.h
+++ b/src/collector/export_shared.h
@@ -37,6 +37,8 @@
 typedef struct exporter_intercept_msg {
     char *liid;
     int liid_len;
+    char *liid_key;
+    int liid_key_len;
     char *authcc;
     int authcc_len;
     char *delivcc;

--- a/src/collector/gtp_worker.c
+++ b/src/collector/gtp_worker.c
@@ -247,8 +247,8 @@ static int init_gtp_intercept(openli_gtp_worker_t *worker,
     }
 
     add_intercept_to_user_intercept_list(&worker->userintercepts, ipint);
-    HASH_ADD_KEYPTR(hh_liid, worker->ipintercepts, ipint->common.liid,
-            ipint->common.liid_len, ipint);
+    HASH_ADD_KEYPTR(hh_liid, worker->ipintercepts, ipint->common.liid_key,
+            ipint->common.liid_key_len, ipint);
     ipint->awaitingconfirm = 0;
 
     return 1;
@@ -301,8 +301,8 @@ static int add_new_gtp_intercept(openli_gtp_worker_t *worker,
         return -1;
     }
 
-    HASH_FIND(hh_liid, worker->ipintercepts, ipint->common.liid,
-            ipint->common.liid_len, found);
+    HASH_FIND(hh_liid, worker->ipintercepts, ipint->common.liid_key,
+            ipint->common.liid_key_len, found);
 
     if (found) {
         update_modified_gtp_intercept(worker, found, ipint);
@@ -324,8 +324,8 @@ static int modify_gtp_intercept(openli_gtp_worker_t *worker,
         return -1;
     }
 
-    HASH_FIND(hh_liid, worker->ipintercepts, ipint->common.liid,
-            ipint->common.liid_len, found);
+    HASH_FIND(hh_liid, worker->ipintercepts, ipint->common.liid_key,
+            ipint->common.liid_key_len, found);
     if (!found) {
         return init_gtp_intercept(worker, ipint);
     } else {
@@ -344,8 +344,8 @@ static int halt_gtp_intercept(openli_gtp_worker_t *worker,
         return -1;
     }
 
-    HASH_FIND(hh_liid, worker->ipintercepts, ipint->common.liid,
-            ipint->common.liid_len, found);
+    HASH_FIND(hh_liid, worker->ipintercepts, ipint->common.liid_key,
+            ipint->common.liid_key_len, found);
     if (found) {
         remove_gtp_intercept(worker, found);
     }

--- a/src/collector/sip_update_state.c
+++ b/src/collector/sip_update_state.c
@@ -478,6 +478,7 @@ void purge_expired_registrations(openli_sip_worker_t *sipworker) {
             msg = calloc(1, sizeof(openli_export_recv_t));
             msg->type = OPENLI_EXPORT_CIN_CLOSE;
             msg->data.cininfo.liid = strdup(reg->common.liid);
+            msg->data.cininfo.authcc = strdup(reg->common.authcc);
             msg->data.cininfo.cin = reg->cin;
             publish_openli_msg(
                     sipworker->zmq_pubsocks[reg->common.seqtrackerid], msg);
@@ -715,7 +716,7 @@ static rtpstreaminf_t *match_call_to_intercept(openli_sip_worker_t *sipworker,
 
     primary = get_primary_callid_using_callid(sipworker->call_state,
             sipworker->call_state_mutex, callid);
-    snprintf(rtpkey, 256, "%s-%u-%s", vint->common.liid, *cin,
+    snprintf(rtpkey, 256, "%s-%u-%s", vint->common.liid_key, *cin,
             primary ? primary : callid);
     HASH_FIND(hh, vint->active_cins, rtpkey, strlen(rtpkey), thisrtp);
 
@@ -1077,7 +1078,7 @@ static int process_sip_other(openli_sip_worker_t *sipworker, char *callid,
             continue;
         }
 
-        snprintf(rtpkey, 256, "%s-%u-%s", vint->common.liid, cin,
+        snprintf(rtpkey, 256, "%s-%u-%s", vint->common.liid_key, cin,
                 primary ? primary : callid);
         HASH_FIND(hh, vint->active_cins, rtpkey, strlen(rtpkey), thisrtp);
         if (thisrtp == NULL) {

--- a/src/collector/sip_worker.c
+++ b/src/collector/sip_worker.c
@@ -947,7 +947,7 @@ static void post_disable_unconfirmed_voip_target(openli_sip_identity_t *sipid,
     HASH_ITER(hh, ref->tgtcalls, cinptr, cintmp) {
         HASH_DELETE(hh, ref->tgtcalls, cinptr);
 
-        snprintf(rtpkey, 512, "%s-%u-%s", v->common.liid, cinptr->cin,
+        snprintf(rtpkey, 512, "%s-%u-%s", v->common.liid_key, cinptr->cin,
                 cinptr->callid);
         HASH_FIND(hh, v->active_cins, rtpkey, strlen(rtpkey), thisrtp);
         if (thisrtp) {
@@ -979,8 +979,8 @@ static void sip_worker_init_voip_intercept(openli_sip_worker_t *sipworker,
                 sipworker->tracker_threads;
     }
 
-    HASH_ADD_KEYPTR(hh_liid, sipworker->voipintercepts, vint->common.liid,
-            vint->common.liid_len, vint);
+    HASH_ADD_KEYPTR(hh_liid, sipworker->voipintercepts, vint->common.liid_key,
+            vint->common.liid_key_len, vint);
     vint->awaitingconfirm = 0;
 
     sip_worker_send_intercept_update_to_seqtracker(sipworker, vint,
@@ -1001,8 +1001,8 @@ static int sip_worker_add_new_voip_intercept(openli_sip_worker_t *sipworker,
         return -1;
     }
 
-    HASH_FIND(hh_liid, sipworker->voipintercepts, vint->common.liid,
-            vint->common.liid_len, found);
+    HASH_FIND(hh_liid, sipworker->voipintercepts, vint->common.liid_key,
+            vint->common.liid_key_len, found);
     if (found) {
         openli_sip_identity_t *tgt;
         libtrace_list_node_t *n;
@@ -1057,8 +1057,8 @@ static int sip_worker_halt_voip_intercept(openli_sip_worker_t *sipworker,
         return -1;
     }
 
-    HASH_FIND(hh_liid, sipworker->voipintercepts, decode->common.liid,
-            decode->common.liid_len, found);
+    HASH_FIND(hh_liid, sipworker->voipintercepts, decode->common.liid_key,
+            decode->common.liid_key_len, found);
     if (!found) {
         if (sipworker->workerid == 0) {
             logger(LOG_INFO,
@@ -1096,8 +1096,8 @@ static int sip_worker_modify_voip_intercept(openli_sip_worker_t *sipworker,
         return -1;
     }
 
-    HASH_FIND(hh_liid, sipworker->voipintercepts, vint->common.liid,
-            vint->common.liid_len, found);
+    HASH_FIND(hh_liid, sipworker->voipintercepts, vint->common.liid_key,
+            vint->common.liid_key_len, found);
     if (!found) {
         sip_worker_init_voip_intercept(sipworker, vint);
     } else {

--- a/src/collector/sip_worker_redirection.c
+++ b/src/collector/sip_worker_redirection.c
@@ -264,7 +264,7 @@ int handle_sip_redirection_packet(openli_sip_worker_t *sipworker,
             sipworker->call_state_mutex, msg->callid);
 
     HASH_ITER(hh_liid, sipworker->voipintercepts, vint, tmp) {
-        snprintf(rtpkey, 256, "%s-%u-%s", vint->common.liid, cin,
+        snprintf(rtpkey, 256, "%s-%u-%s", vint->common.liid_key, cin,
                 callid ? callid : msg->callid);
         HASH_FIND(hh, vint->active_cins, rtpkey, strlen(rtpkey), thisrtp);
         if (thisrtp == NULL) {

--- a/src/collector/timed_intercept.c
+++ b/src/collector/timed_intercept.c
@@ -45,7 +45,7 @@ static inline void remove_time_event(Pvoid_t *timeevents,
         return;
     }
 
-    HASH_FIND(hh, timeentry->events, common->liid, common->liid_len, found);
+    HASH_FIND(hh, timeentry->events, common->liid_key, common->liid_key_len, found);
     if (!found) {
         return;
     }
@@ -82,7 +82,7 @@ static inline void add_time_event(Pvoid_t *timeevents, void *intercept,
         *pval = (Word_t)timeentry;
     }
 
-    HASH_FIND(hh, timeentry->events, common->liid, common->liid_len, found);
+    HASH_FIND(hh, timeentry->events, common->liid_key, common->liid_key_len, found);
     if (found) {
         HASH_DELETE(hh, timeentry->events, found);
         free(found->liid);
@@ -91,9 +91,9 @@ static inline void add_time_event(Pvoid_t *timeevents, void *intercept,
     found = calloc(1, sizeof(struct upcoming_intercept_event));
     found->event_type = evtype;
     found->intercept = intercept;
-    found->liid = strdup(common->liid);
+    found->liid = strdup(common->liid_key);
 
-    HASH_ADD_KEYPTR(hh, timeentry->events, found->liid, common->liid_len,
+    HASH_ADD_KEYPTR(hh, timeentry->events, found->liid, common->liid_key_len,
             found);
 }
 

--- a/src/collector/udp_sink_worker.c
+++ b/src/collector/udp_sink_worker.c
@@ -526,7 +526,9 @@ static int process_control_message(udp_sink_local_t *local, char *key) {
 
         if (msg->type == OPENLI_EXPORT_INTERCEPT_DETAILS ||
                 msg->type == OPENLI_EXPORT_INTERCEPT_CHANGED) {
-            if (strcmp(local->expectedliid, msg->data.cept.liid) != 0) {
+            if (strcmp(local->expectedliid, msg->data.cept.liid) != 0 ||
+                    (msg->data.cept.authcc &&
+                     strcmp(local->authcc, msg->data.cept.authcc) != 0)) {
                 logger(LOG_INFO,
                         "OpenLI: UDP sink worker '%s' was expecting to be responsible for intercept '%s', but it was provided details for '%s'?",
                         key, local->expectedliid, msg->data.cept.liid);
@@ -594,7 +596,9 @@ static int process_control_message(udp_sink_local_t *local, char *key) {
             local->cept = msg;
             local->dest_mediator = msg->destid;
         } else if (msg->type == OPENLI_EXPORT_INTERCEPT_OVER) {
-            if (strcmp(local->expectedliid, msg->data.cept.liid) != 0) {
+            if (strcmp(local->expectedliid, msg->data.cept.liid) != 0 ||
+                    (msg->data.cept.authcc &&
+                     strcmp(local->authcc, msg->data.cept.authcc) != 0)) {
                 logger(LOG_INFO,
                         "OpenLI: UDP sink worker '%s' is responsible for intercept '%s', but it was told to cease interception for '%s'?",
                         key, local->expectedliid, msg->data.cept.liid);

--- a/src/collector/x2x3_ingest.c
+++ b/src/collector/x2x3_ingest.c
@@ -296,6 +296,15 @@ static inline void populate_intercept_common(published_intercept_msg_t *src,
     /* already NULLed by move; just ensure len is 0 */
     src->encryptkey = NULL;
     src->encryptkey_len = 0;
+
+    if (dst->liid && dst->authcc) {
+        char errbuf[256];
+        if (set_intercept_liid_key(dst, errbuf, sizeof(errbuf)) < 0) {
+            logger(LOG_INFO,
+                    "OpenLI: unable to derive intercept key for X2/X3 intercept %s: %s",
+                    dst->liid, errbuf);
+        }
+    }
 }
 
 static inline uint8_t x2x3dir_to_etsidir(uint16_t xdir) {
@@ -1106,13 +1115,16 @@ static void withdraw_xid_ipintercept(x_input_t *xinp,
         openli_export_recv_t *msg) {
 
     ipintercept_t *found;
+    char liid_key[2048];
 
-    if (msg->data.cept.liid == NULL) {
+    if (msg->data.cept.liid == NULL || msg->data.cept.authcc == NULL) {
         return;
     }
 
-    HASH_FIND(hh_liid, xinp->ipintercepts, msg->data.cept.liid,
-            strlen(msg->data.cept.liid), found);
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", msg->data.cept.authcc,
+            msg->data.cept.liid);
+    HASH_FIND(hh_liid, xinp->ipintercepts, liid_key,
+            strlen(liid_key), found);
     if (!found) {
         return;
     }
@@ -1127,13 +1139,16 @@ static void withdraw_xid_voipintercept(x_input_t *xinp,
         openli_export_recv_t *msg) {
 
     voipintercept_t *found;
+    char liid_key[2048];
 
-    if (msg->data.cept.liid == NULL) {
+    if (msg->data.cept.liid == NULL || msg->data.cept.authcc == NULL) {
         return;
     }
 
-    HASH_FIND(hh_liid, xinp->voipintercepts, msg->data.cept.liid,
-            strlen(msg->data.cept.liid), found);
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", msg->data.cept.authcc,
+            msg->data.cept.liid);
+    HASH_FIND(hh_liid, xinp->voipintercepts, liid_key,
+            strlen(liid_key), found);
     if (!found) {
         return;
     }
@@ -1148,13 +1163,16 @@ static void add_or_update_xid_voipintercept(x_input_t *xinp,
         openli_export_recv_t *msg) {
 
     voipintercept_t *found;
+    char liid_key[2048];
 
-    if (msg->data.cept.liid == NULL) {
+    if (msg->data.cept.liid == NULL || msg->data.cept.authcc == NULL) {
         return;
     }
 
-    HASH_FIND(hh_liid, xinp->voipintercepts, msg->data.cept.liid,
-            strlen(msg->data.cept.liid), found);
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", msg->data.cept.authcc,
+            msg->data.cept.liid);
+    HASH_FIND(hh_liid, xinp->voipintercepts, liid_key,
+            strlen(liid_key), found);
     if (found) {
         remove_existing_from_uuid_map(&(xinp->voipxids), &(found->common));
         update_intercept_common(&(msg->data.cept), &(found->common),
@@ -1163,8 +1181,8 @@ static void add_or_update_xid_voipintercept(x_input_t *xinp,
         found = calloc(1, sizeof(voipintercept_t));
         populate_intercept_common(&(msg->data.cept), &(found->common),
                 msg->destid);
-        HASH_ADD_KEYPTR(hh_liid, xinp->voipintercepts, found->common.liid,
-                found->common.liid_len, found);
+        HASH_ADD_KEYPTR(hh_liid, xinp->voipintercepts, found->common.liid_key,
+                found->common.liid_key_len, found);
 
     }
     update_uuid_map(&(xinp->voipxids), &(found->common),
@@ -1175,13 +1193,16 @@ static void add_or_update_xid_ipintercept(x_input_t *xinp,
         openli_export_recv_t *msg) {
 
     ipintercept_t *found;
+    char liid_key[2048];
 
-    if (msg->data.cept.liid == NULL) {
+    if (msg->data.cept.liid == NULL || msg->data.cept.authcc == NULL) {
         return;
     }
 
-    HASH_FIND(hh_liid, xinp->ipintercepts, msg->data.cept.liid,
-            strlen(msg->data.cept.liid), found);
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", msg->data.cept.authcc,
+            msg->data.cept.liid);
+    HASH_FIND(hh_liid, xinp->ipintercepts, liid_key,
+            strlen(liid_key), found);
     if (found) {
         remove_existing_from_uuid_map(&(xinp->ipxids), &(found->common));
         update_intercept_common(&(msg->data.cept), &(found->common),
@@ -1203,8 +1224,8 @@ static void add_or_update_xid_ipintercept(x_input_t *xinp,
         if (found->username) {
             found->username_len = strlen(found->username);
         }
-        HASH_ADD_KEYPTR(hh_liid, xinp->ipintercepts, found->common.liid,
-                found->common.liid_len, found);
+        HASH_ADD_KEYPTR(hh_liid, xinp->ipintercepts, found->common.liid_key,
+                found->common.liid_key_len, found);
     }
     update_uuid_map(&(xinp->ipxids), &(found->common),
             OPENLI_INTERCEPT_TYPE_IP, found);

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -131,20 +131,12 @@ int set_intercept_liid_key(intercept_common_t *common, char *errorstring,
         return -1;
     }
 
-    /* A separator inside the authCC would make the key ambiguous, e.g.
-     * ("AB-C", "D") and ("AB", "C-D") would both derive "AB-C-D". ETSI
-     * TS 102 232-1 requires an ISO-3166-1 alpha-2 code here, so this rejects
-     * nothing that was ever valid.
-     */
     if (strchr(common->authcc, '-') != NULL) {
         snprintf(errorstring, errorstringsize,
                 "'authcc' must not contain a '-' character");
         return -1;
     }
 
-    /* Derived from strlen() rather than the _len members so that callers do
-     * not have to populate those first.
-     */
     free(common->liid_key);
     common->liid_key_len = strlen(common->authcc) + strlen(common->liid) + 1;
     common->liid_key = calloc(common->liid_key_len + 1, sizeof(char));
@@ -517,7 +509,7 @@ rtpstreaminf_t *create_rtpstream(voipintercept_t *vint, uint32_t cin,
     }
 
     copy_intercept_common(&(vint->common), &(newcin->common));
-    snprintf(newcin->streamkey, 256, "%s-%u-%s", vint->common.liid, cin,
+    snprintf(newcin->streamkey, 256, "%s-%u-%s", vint->common.liid_key, cin,
             callid);
     return newcin;
 }
@@ -726,6 +718,9 @@ void clean_intercept_udp_sink(intercept_udp_sink_t *sink) {
     }
     if (sink->liid) {
         free(sink->liid);
+    }
+    if (sink->authcc) {
+        free(sink->authcc);
     }
     sink->enabled = 0;
 }
@@ -1231,7 +1226,7 @@ staticipsession_t *create_staticipsession(ipintercept_t *ipint, char *rangestr,
     statint->nextseqno = 0;
     copy_intercept_common(&(ipint->common), &(statint->common));
     statint->key = (char *)calloc(1, 128);
-    snprintf(statint->key, 127, "%s-%u", ipint->common.liid, cin);
+    snprintf(statint->key, 127, "%s-%u", ipint->common.liid_key, cin);
 
     return statint;
 }
@@ -1245,6 +1240,9 @@ void free_single_staticiprange(static_ipranges_t *ipr) {
     }
     if (ipr->liid) {
         free(ipr->liid);
+    }
+    if (ipr->authcc) {
+        free(ipr->authcc);
     }
     free(ipr);
 }
@@ -1298,7 +1296,7 @@ ipsession_t *create_ipsession(ipintercept_t *ipint, uint32_t cin,
         free(ipsess);
         return NULL;
     }
-    snprintf(ipsess->streamkey, 256, "%s-%u", ipint->common.liid, cin);
+    snprintf(ipsess->streamkey, 256, "%s-%u", ipint->common.liid_key, cin);
 
     return ipsess;
 }
@@ -1364,13 +1362,13 @@ static int add_email_targetid_to_user_intercept_list(
                 strlen(found->origaddress), found);
     }
 
-    HASH_FIND(hh, found->intlist, em->common.liid, em->common.liid_len, intref);
+    HASH_FIND(hh, found->intlist, em->common.liid_key, em->common.liid_key_len, intref);
     if (!intref) {
         intref = calloc(1, sizeof(email_intercept_ref_t));
         intref->em = em;
 
-        HASH_ADD_KEYPTR(hh, found->intlist, em->common.liid,
-                em->common.liid_len, intref);
+        HASH_ADD_KEYPTR(hh, found->intlist, em->common.liid_key,
+                em->common.liid_key_len, intref);
     }
     return 0;
 }
@@ -1401,13 +1399,13 @@ static int add_email_address_to_user_intercept_list(
                 strlen(found->emailaddr), found);
     }
 
-    HASH_FIND(hh, found->intlist, em->common.liid, em->common.liid_len, intref);
+    HASH_FIND(hh, found->intlist, em->common.liid_key, em->common.liid_key_len, intref);
     if (!intref) {
         intref = calloc(1, sizeof(email_intercept_ref_t));
         intref->em = em;
 
-        HASH_ADD_KEYPTR(hh, found->intlist, em->common.liid,
-                em->common.liid_len, intref);
+        HASH_ADD_KEYPTR(hh, found->intlist, em->common.liid_key,
+                em->common.liid_key_len, intref);
     }
     return 0;
 }
@@ -1508,8 +1506,8 @@ int add_intercept_to_user_intercept_list(user_intercept_list_t **ulist,
                 found);
     }
 
-    HASH_FIND(hh_user, found->intlist, ipint->common.liid,
-            ipint->common.liid_len, check);
+    HASH_FIND(hh_user, found->intlist, ipint->common.liid_key,
+            ipint->common.liid_key_len, check);
     if (check) {
         logger(LOG_INFO,
                 "OpenLI: user %s already has an intercept with ID %s?",
@@ -1517,8 +1515,8 @@ int add_intercept_to_user_intercept_list(user_intercept_list_t **ulist,
         return -1;
     }
 
-    HASH_ADD_KEYPTR(hh_user, found->intlist, ipint->common.liid,
-            ipint->common.liid_len, ipint);
+    HASH_ADD_KEYPTR(hh_user, found->intlist, ipint->common.liid_key,
+            ipint->common.liid_key_len, ipint);
     return 0;
 }
 
@@ -1541,7 +1539,7 @@ int remove_intercept_from_email_user_intercept_list(
             strlen(tgt->address), found);
 
     if (found) {
-        HASH_FIND(hh, found->intlist, em->common.liid, em->common.liid_len,
+        HASH_FIND(hh, found->intlist, em->common.liid_key, em->common.liid_key_len,
                 existing);
         if (!existing) {
             return 0;
@@ -1569,7 +1567,7 @@ int remove_intercept_from_email_user_intercept_list(
     HASH_FIND(hh_sha, ulist->targets, tgt->sha512, strlen(tgt->sha512),
             sha_ref);
     if (sha_ref) {
-        HASH_FIND(hh, sha_ref->intlist, em->common.liid, em->common.liid_len,
+        HASH_FIND(hh, sha_ref->intlist, em->common.liid_key, em->common.liid_key_len,
                 existing);
         if (!existing) {
             return 0;
@@ -1619,8 +1617,8 @@ int remove_intercept_from_user_intercept_list(user_intercept_list_t **ulist,
         return 0;
     }
 
-    HASH_FIND(hh_user, found->intlist, ipint->common.liid,
-            ipint->common.liid_len, existing);
+    HASH_FIND(hh_user, found->intlist, ipint->common.liid_key,
+            ipint->common.liid_key_len, existing);
     if (!existing) {
         return 0;
     }

--- a/src/intercept.c
+++ b/src/intercept.c
@@ -122,6 +122,43 @@ int openli_parse_liid_string(char *liidstr, char **storage,
     return 1;
 }
 
+int set_intercept_liid_key(intercept_common_t *common, char *errorstring,
+        size_t errorstringsize) {
+
+    if (common->liid == NULL || common->authcc == NULL) {
+        snprintf(errorstring, errorstringsize,
+                "both 'liid' and 'authcc' must be set before deriving a key");
+        return -1;
+    }
+
+    /* A separator inside the authCC would make the key ambiguous, e.g.
+     * ("AB-C", "D") and ("AB", "C-D") would both derive "AB-C-D". ETSI
+     * TS 102 232-1 requires an ISO-3166-1 alpha-2 code here, so this rejects
+     * nothing that was ever valid.
+     */
+    if (strchr(common->authcc, '-') != NULL) {
+        snprintf(errorstring, errorstringsize,
+                "'authcc' must not contain a '-' character");
+        return -1;
+    }
+
+    /* Derived from strlen() rather than the _len members so that callers do
+     * not have to populate those first.
+     */
+    free(common->liid_key);
+    common->liid_key_len = strlen(common->authcc) + strlen(common->liid) + 1;
+    common->liid_key = calloc(common->liid_key_len + 1, sizeof(char));
+    if (common->liid_key == NULL) {
+        common->liid_key_len = 0;
+        snprintf(errorstring, errorstringsize,
+                "out of memory while deriving an intercept key");
+        return -1;
+    }
+    snprintf(common->liid_key, common->liid_key_len + 1, "%s-%s",
+            common->authcc, common->liid);
+    return 1;
+}
+
 int openli_parse_encryption_key_string(char *enckeystr, uint8_t *keybuf,
         size_t *keylen, char *errorstring, size_t errorstringsize) {
 
@@ -163,6 +200,8 @@ static inline void copy_intercept_common(intercept_common_t *src,
     dest->liid_format = src->liid_format;
     dest->authcc = strdup(src->authcc);
     dest->delivcc = strdup(src->delivcc);
+    dest->liid_key = src->liid_key ? strdup(src->liid_key) : NULL;
+    dest->liid_key_len = src->liid_key_len;
 
     if (src->targetagency) {
         dest->targetagency = strdup(src->targetagency);
@@ -543,6 +582,10 @@ static inline void free_intercept_common(intercept_common_t *cept) {
 
     if (cept->liid) {
         free(cept->liid);
+    }
+
+    if (cept->liid_key) {
+        free(cept->liid_key);
     }
 
     if (cept->authcc) {

--- a/src/intercept.h
+++ b/src/intercept.h
@@ -141,6 +141,7 @@ typedef enum {
 typedef struct static_ipranges {
     char *rangestr;
     char *liid;
+    char *authcc;
     uint32_t cin;
     uint8_t awaitingconfirm;
     UT_hash_handle hh;
@@ -154,12 +155,6 @@ typedef struct intercept_common {
     int liid_len;
     int authcc_len;
     int delivcc_len;
-
-    /** LIIDs are only required to be unique within an authorising country,
-     *  so every internal lookup, queue name and routing decision must key on
-     *  this instead of the LIID alone. Never sent to an agency -- the LIID
-     *  that appears in the ETSI PSHeader is still 'liid' above.
-     */
     char *liid_key;
     int liid_key_len;
     uint32_t destid;
@@ -224,6 +219,7 @@ typedef struct intercept_udp_sink {
 
     char *key;
     char *liid;
+    char *authcc;
     UT_hash_handle hh;
 
 } intercept_udp_sink_t;

--- a/src/intercept.h
+++ b/src/intercept.h
@@ -154,6 +154,14 @@ typedef struct intercept_common {
     int liid_len;
     int authcc_len;
     int delivcc_len;
+
+    /** LIIDs are only required to be unique within an authorising country,
+     *  so every internal lookup, queue name and routing decision must key on
+     *  this instead of the LIID alone. Never sent to an agency -- the LIID
+     *  that appears in the ETSI PSHeader is still 'liid' above.
+     */
+    char *liid_key;
+    int liid_key_len;
     uint32_t destid;
     char *targetagency;
     int seqtrackerid;
@@ -777,6 +785,8 @@ int openli_parse_encryption_key_string(char *enckeystr, uint8_t *keybuf,
         size_t *keylen, char *errorstring, size_t errorstringsize);
 int openli_parse_liid_string(char *liidstr, char **storage,
         openli_liid_format_t *fmt, char *errorstring, size_t errorstringsize);
+int set_intercept_liid_key(intercept_common_t *common, char *errorstring,
+        size_t errorstringsize);
 
 #endif
 // vim: set sw=4 tabstop=4 softtabstop=4 expandtab :

--- a/src/mediator/lea_send_thread.c
+++ b/src/mediator/lea_send_thread.c
@@ -737,7 +737,7 @@ int insert_lea_liid_mapping(lea_thread_state_t *state, added_liid_t *toadd) {
     if (r < 0) {
         logger(LOG_INFO,
                 "OpenLI Mediator: WARNING failed to add %s -> %s to LIID map",
-                toadd->liid, state->agencyid);
+                toadd->liid_key, state->agencyid);
         return -1;
     }
 
@@ -750,15 +750,15 @@ int insert_lea_liid_mapping(lea_thread_state_t *state, added_liid_t *toadd) {
 
     /* Register to consume from the LIID's internal RMQ queues */
     if ((register_mediator_iri_RMQ_consumer(
-                    state->agency.hi2->rmq_consumer, toadd->liid) < 0) ||
+                    state->agency.hi2->rmq_consumer, toadd->liid_key) < 0) ||
             (register_mediator_cc_RMQ_consumer(state->agency.hi3->rmq_consumer,
-                    toadd->liid) < 0)) {
+                    toadd->liid_key) < 0)) {
         logger(LOG_INFO,
             "OpenLI Mediator: WARNING failed to register RMQ for LIID %s -> %s",
-            toadd->liid, state->agencyid);
+            toadd->liid_key, state->agencyid);
     } else {
         logger(LOG_INFO, "OpenLI Mediator: added %s -> %s to LIID map",
-                toadd->liid, state->agencyid);
+                toadd->liid_key, state->agencyid);
     }
     return 1;
 }
@@ -911,12 +911,18 @@ static void publish_hi1_notification(lea_thread_state_t *state,
     payload_encryption_method_t encmethod = OPENLI_PAYLOAD_ENCRYPTION_NONE;
     char *operatorid = NULL;
     char *shortoperatorid = NULL;
+    char liid_key[2048];
 
     if (!ndata) {
         return;
     }
 
-    liidmap = lookup_liid_agency_mapping(&(state->active_liids), ndata->liid);
+    if (ndata->liid == NULL || ndata->authcc == NULL) {
+        goto freehi1;
+    }
+
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", ndata->authcc, ndata->liid);
+    liidmap = lookup_liid_agency_mapping(&(state->active_liids), liid_key);
     if (!liidmap) {
         goto freehi1;
     }
@@ -1109,7 +1115,7 @@ static int process_agency_messages(lea_thread_state_t *state) {
                  * from our current handovers so we don't steal records for
                  * it and send them to the wrong agency.
                  */
-                purge_lea_liid_mapping(state, added->liid);
+                purge_lea_liid_mapping(state, added->liid_key);
             } else {
                 /* If the agency ID matches ours, then we should add it to
                  * our handovers.
@@ -1118,6 +1124,7 @@ static int process_agency_messages(lea_thread_state_t *state) {
             }
 
             free(added->liid);
+            free(added->liid_key);
             free(added->agencyid);
             free(added);
         }

--- a/src/mediator/liidmapping.c
+++ b/src/mediator/liidmapping.c
@@ -113,7 +113,7 @@ int add_liid_agency_mapping(liid_map_t *map, added_liid_t *toadd) {
     PWord_t jval;
 	liid_map_entry_t *m;
 
-    JSLG(jval, map->liid_array, (unsigned char *)(toadd->liid));
+    JSLG(jval, map->liid_array, (unsigned char *)(toadd->liid_key));
     if (jval != NULL) {
         int ret = 0;
 
@@ -145,7 +145,7 @@ int add_liid_agency_mapping(liid_map_t *map, added_liid_t *toadd) {
 
     m->withdrawn = 0;
     m->unconfirmed = 0;
-    m->liid = strdup(toadd->liid);
+    m->liid = strdup(toadd->liid_key);
     m->ccqueue_deleted = 0;
     m->iriqueue_deleted = 0;
     m->encrypt = toadd->encrypt;

--- a/src/mediator/liidmapping.h
+++ b/src/mediator/liidmapping.h
@@ -38,6 +38,8 @@ typedef struct liidmapping liid_map_entry_t;
 typedef struct added_liid {
     /** The LIID */
     char *liid;
+    /** The authCC-qualified intercept key ("<authcc>-<liid>") */
+    char *liid_key;
     /** Whether the LIID should be encoded as ASCII or binary octets */
     openli_liid_format_t liid_format;
 
@@ -59,7 +61,7 @@ typedef struct added_liid {
  *  the intercepted records for that LIID
  */
 struct liidmapping {
-    /** The LIID, as a string */
+    /** The authCC-qualified intercept key ("<authcc>-<liid>"), as a string */
     char *liid;
 
     /** Flag that indicates whether this mapping is unconfirmed by the

--- a/src/mediator/mediator.c
+++ b/src/mediator/mediator.c
@@ -701,14 +701,15 @@ freehi1:
 static int receive_cease(mediator_state_t *state, uint8_t *msgbody,
         uint16_t msglen) {
 
-    char *liid = NULL;
+    char *liid = NULL, *authcc = NULL;
+    char liid_key[2048];
     lea_thread_msg_t msg;
     lea_thread_state_t *lea_t, *tmp;
     col_thread_msg_t cmsg;
     coll_recv_t *col_t, *ctmp;
 
     /** See netcomms.c for this method */
-    if (decode_cease_mediation(msgbody, msglen, &liid) == -1) {
+    if (decode_cease_mediation(msgbody, msglen, &liid, &authcc) == -1) {
         if (state->provisioner.disable_log == 0) {
             logger(LOG_INFO,
                     "OpenLI Mediator: received invalid cease mediation command from provisioner.");
@@ -717,9 +718,13 @@ static int receive_cease(mediator_state_t *state, uint8_t *msgbody,
     }
 
     /* Error while decoding, stop */
-    if (liid == NULL) {
+    if (liid == NULL || authcc == NULL) {
+        free(liid);
+        free(authcc);
         return -1;
     }
+
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", authcc, liid);
 
     /* Send the remove message to all LEA threads -- this shouldn't be a
      * huge workload for the LEA threads to deal with.
@@ -729,7 +734,7 @@ static int receive_cease(mediator_state_t *state, uint8_t *msgbody,
     memset(&msg, 0, sizeof(msg));
     HASH_ITER(hh, state->agency_threads.threads, lea_t, tmp) {
         msg.type = MED_LEA_MESSAGE_REMOVE_LIID;
-        msg.data = strdup(liid);
+        msg.data = strdup(liid_key);
 
         libtrace_message_queue_put(&(lea_t->in_main), &msg);
     }
@@ -737,11 +742,12 @@ static int receive_cease(mediator_state_t *state, uint8_t *msgbody,
     memset(&cmsg, 0, sizeof(cmsg));
     HASH_ITER(hh, state->collector_threads.threads, col_t, ctmp) {
         cmsg.type = MED_COLL_LIID_WITHDRAW;
-        cmsg.arg = (uint64_t)strdup(liid);
+        cmsg.arg = (uint64_t)strdup(liid_key);
         libtrace_message_queue_put(&(col_t->in_main), &cmsg);
     }
 
     free(liid);
+    free(authcc);
     return 0;
 }
 
@@ -758,7 +764,8 @@ static int receive_cease(mediator_state_t *state, uint8_t *msgbody,
 static int receive_liid_mapping(mediator_state_t *state, uint8_t *msgbody,
         uint16_t msglen) {
 
-    char *agencyid = NULL, *liid = NULL;
+    char *agencyid = NULL, *liid = NULL, *authcc = NULL;
+    char liid_key[2048];
     int found = 0, ret = 0;
     lea_thread_msg_t msg;
     lea_thread_state_t *target;
@@ -773,17 +780,19 @@ static int receive_liid_mapping(mediator_state_t *state, uint8_t *msgbody,
     liid = NULL;
 
     /* See netcomms.c for this method */
-    if (decode_liid_mapping(msgbody, msglen, &agencyid, &liid, encryptkey,
-            &encryptlen, &encmethod, &liidfmt) == -1) {
+    if (decode_liid_mapping(msgbody, msglen, &agencyid, &liid, &authcc,
+            encryptkey, &encryptlen, &encmethod, &liidfmt) == -1) {
         logger(LOG_INFO, "OpenLI Mediator: receive invalid LIID mapping from provisioner.");
         ret = -1;
         goto tidyup;
     }
 
-    if (agencyid == NULL || liid == NULL) {
+    if (agencyid == NULL || liid == NULL || authcc == NULL) {
         ret = -1;
         goto tidyup;
     }
+
+    snprintf(liid_key, sizeof(liid_key), "%s-%s", authcc, liid);
 
     /*
      * Include agencyid and LIID in msg.data and send msg to ALL LEA
@@ -807,6 +816,7 @@ static int receive_liid_mapping(mediator_state_t *state, uint8_t *msgbody,
 
         added = calloc(1, sizeof(added_liid_t));
         added->liid = strdup(liid);
+        added->liid_key = strdup(liid_key);
         added->liid_format = liidfmt;
         added->agencyid = strdup(agencyid);
         if (encryptlen > 0) {
@@ -832,6 +842,9 @@ static int receive_liid_mapping(mediator_state_t *state, uint8_t *msgbody,
 tidyup:
     if (liid) {
         free(liid);
+    }
+    if (authcc) {
+        free(authcc);
     }
     if (agencyid) {
         free(agencyid);

--- a/src/mediator/pcapthread.c
+++ b/src/mediator/pcapthread.c
@@ -333,21 +333,28 @@ pcaptraceerr:
  */
 static active_pcap_output_t *create_new_pcap_output(
         lea_thread_state_t *state, pcap_thread_state_t *pstate,
-        char *liid) {
+        char *liid, char *liid_key) {
 
     active_pcap_output_t *act;
 
     HASH_FIND(hh, pstate->active, liid, strlen(liid), act);
     if (act) {
+        if (strcmp(act->liid_key, liid_key) != 0) {
+            logger(LOG_INFO,
+                    "OpenLI Mediator: WARNING two pcapdisk intercepts (%s and %s) share the LIID %s -- their packets will be written into the same pcap files.",
+                    act->liid_key, liid_key, liid);
+        }
         return act;
     }
 
     act = (active_pcap_output_t *)malloc(sizeof(active_pcap_output_t));
     act->liid = strdup(liid);
+    act->liid_key = strdup(liid_key);
     act->uri = NULL;
 
     if (open_pcap_output_file(state, pstate, act) == -1) {
         free(act->liid);
+        free(act->liid_key);
         if (act->uri) {
             free(act->uri);
         }
@@ -375,6 +382,7 @@ static uint32_t write_rawip_to_pcap(uint8_t *nextrec, uint64_t bufrem,
     active_pcap_output_t *pcapout;
     uint32_t pdulen;
     unsigned char liidspace[2048];
+    char *liidstart;
     uint16_t liidlen;
     uint8_t *pktdata;
 
@@ -390,8 +398,8 @@ static uint32_t write_rawip_to_pcap(uint8_t *nextrec, uint64_t bufrem,
         return sizeof(uint32_t);
     }
 
-    /* Next is the LIID, which is encoded as a 2 byte size field followed
-     * by the LIID string itself (not null-terminated)
+    /* Next is the intercept key, which is encoded as a 2 byte size field
+     * followed by the key string itself (not null-terminated)
      */
     extract_liid_from_exported_msg(nextrec, bufrem, liidspace, 2048, &liidlen);
 
@@ -401,8 +409,14 @@ static uint32_t write_rawip_to_pcap(uint8_t *nextrec, uint64_t bufrem,
         logger(LOG_INFO, "OpenLI Mediator: raw IP packet is too large to write as a pcap packet, possibly corrupt");
         return pdulen + sizeof(uint32_t);
     }
-    HASH_FIND(hh, pstate->active, liidspace,
-            strlen((const char *)liidspace), pcapout);
+
+    liidstart = strchr((char *)liidspace, '-');
+    if (liidstart != NULL) {
+        liidstart ++;
+    } else {
+        liidstart = (char *)liidspace;
+    }
+    HASH_FIND(hh, pstate->active, liidstart, strlen(liidstart), pcapout);
 
     /* Hopefully, we already know about this LIID and have a pcap output
      * handle all set up and ready for it. If not, let's just skip past it.
@@ -731,6 +745,7 @@ static void pcap_flush_traces(pcap_thread_state_t *pstate) {
             pcapout->out = NULL;
             HASH_DELETE(hh, pstate->active, pcapout);
             free(pcapout->liid);
+            free(pcapout->liid_key);
             if (pcapout->uri) {
                 free(pcapout->uri);
             }
@@ -771,6 +786,7 @@ static void pcap_rotate_traces(lea_thread_state_t *state,
             }
             HASH_DELETE(hh, pstate->active, pcapout);
             free(pcapout->liid);
+            free(pcapout->liid_key);
             if (pcapout->uri) {
                 free(pcapout->uri);
             }
@@ -785,12 +801,16 @@ static void pcap_rotate_traces(lea_thread_state_t *state,
  *  @param pstate           The pcap-specific state for the thread
  *  @param liid             The LIID to disable pcap output for
  */
-static void pcap_disable_liid(pcap_thread_state_t *pstate, char *liid) {
+static void pcap_disable_liid(pcap_thread_state_t *pstate, char *liid,
+        char *liid_key) {
 
     active_pcap_output_t *pcapout;
 
     HASH_FIND(hh, pstate->active, liid, strlen(liid), pcapout);
     if (!pcapout) {
+        return;
+    }
+    if (strcmp(pcapout->liid_key, liid_key) != 0) {
         return;
     }
     logger(LOG_INFO, "OpenLI Mediator: disabling pcap output for LIID '%s'",
@@ -805,6 +825,7 @@ static void pcap_disable_liid(pcap_thread_state_t *pstate, char *liid) {
         free(pcapout->uri);
     }
     free(pcapout->liid);
+    free(pcapout->liid_key);
     free(pcapout);
 }
 
@@ -845,14 +866,14 @@ static void add_new_pcapdisk_liid(lea_thread_state_t *state,
     if (strcmp(added->agencyid, state->agencyid) != 0) {
         /* This LIID has switched to another agency, so close any
          * existing pcap output and disable the pcap-specific RMQs */
-        pcap_disable_liid(pstate, added->liid);
-        if (purge_lea_liid_mapping(state, added->liid) > 0) {
+        pcap_disable_liid(pstate, added->liid, added->liid_key);
+        if (purge_lea_liid_mapping(state, added->liid_key) > 0) {
             if (deregister_mediator_rawip_RMQ_consumer(
                         pstate->rawip_handover->rmq_consumer,
-                        added->liid) < 0) {
+                        added->liid_key) < 0) {
                 logger(LOG_INFO,
                         "OpenLI Mediator: WARNING failed to deregister rawip RMQ for LIID %s -> %s",
-                        added->liid, state->agencyid);
+                        added->liid_key, state->agencyid);
             }
         }
     } else {
@@ -861,19 +882,21 @@ static void add_new_pcapdisk_liid(lea_thread_state_t *state,
         if (r > 0) {
             /* Only register with RMQ if this LIID is "new" */
             if (register_mediator_rawip_RMQ_consumer(
-                    pstate->rawip_handover->rmq_consumer, added->liid) < 0) {
+                    pstate->rawip_handover->rmq_consumer,
+                    added->liid_key) < 0) {
                 logger(LOG_INFO,
                         "OpenLI Mediator: WARNING failed to register rawip RMQ for LIID %s in pcap thread",
-                        added->liid);
+                        added->liid_key);
             }
         }
-        if (create_new_pcap_output(state, pstate, added->liid)
-                == NULL) {
+        if (create_new_pcap_output(state, pstate, added->liid,
+                added->liid_key) == NULL) {
             logger(LOG_INFO, "OpenLI Mediator: failed to create new pcap output entity for LIID %s", added->liid);
         }
     }
 
     free(added->liid);
+    free(added->liid_key);
     free(added->agencyid);
     free(added);
 }

--- a/src/mediator/pcapthread.h
+++ b/src/mediator/pcapthread.h
@@ -40,6 +40,9 @@ typedef struct active_pcap_output {
     /** The LIID for the intercept that is being written as pcap */
     char *liid;
 
+    /** The authCC-qualified intercept key that this output was created for */
+    char *liid_key;
+
     /** The URI for the output file (i.e. the file format and path) */
     char *uri;
 

--- a/src/netcomms.c
+++ b/src/netcomms.c
@@ -338,19 +338,20 @@ int push_udp_sink_onto_net_buffer(net_buffer_t *nb, const char *addr,
     return (int)totallen;
 }
 
-#define LIIDMAP_BODY_LEN(agency, liid, enclen) \
-    (strlen(agency) + strlen(liid) + sizeof(payload_encryption_method_t) + \
+#define LIIDMAP_BODY_LEN(agency, liid, authcc, enclen) \
+    (strlen(agency) + strlen(liid) + strlen(authcc) + \
+    sizeof(payload_encryption_method_t) + \
     sizeof(openli_liid_format_t) + \
-    ( enclen > 0 ? enclen + 4 : 0) + (4 * 4))
+    ( enclen > 0 ? enclen + 4 : 0) + (5 * 4))
 
 int push_liid_mapping_onto_net_buffer(net_buffer_t *nb, char *agency,
-        char *liid, uint8_t *encryptkey, size_t encryptlen,
+        char *liid, char *authcc, uint8_t *encryptkey, size_t encryptlen,
         payload_encryption_method_t method, openli_liid_format_t liidformat) {
 
     ii_header_t hdr;
     uint16_t totallen;
 
-    totallen = LIIDMAP_BODY_LEN(agency, liid, encryptlen);
+    totallen = LIIDMAP_BODY_LEN(agency, liid, authcc, encryptlen);
     populate_header(&hdr, OPENLI_PROTO_MEDIATE_INTERCEPT, totallen, 0);
 
     if (push_generic_onto_net_buffer(nb, (uint8_t *)(&hdr),
@@ -365,6 +366,11 @@ int push_liid_mapping_onto_net_buffer(net_buffer_t *nb, char *agency,
 
     if (push_tlv(nb, OPENLI_PROTO_FIELD_LIID, (uint8_t *)(liid),
                 strlen(liid)) == -1) {
+        return -1;
+    }
+
+    if (push_tlv(nb, OPENLI_PROTO_FIELD_AUTHCC, (uint8_t *)(authcc),
+                strlen(authcc)) == -1) {
         return -1;
     }
 
@@ -389,11 +395,11 @@ int push_liid_mapping_onto_net_buffer(net_buffer_t *nb, char *agency,
 }
 
 int push_cease_mediation_onto_net_buffer(net_buffer_t *nb, char *liid,
-        int liid_len) {
+        int liid_len, char *authcc, int authcc_len) {
     ii_header_t hdr;
     uint16_t totallen;
 
-    totallen = liid_len + 4;
+    totallen = liid_len + authcc_len + (2 * 4);
     populate_header(&hdr, OPENLI_PROTO_CEASE_MEDIATION, totallen, 0);
 
     if (push_generic_onto_net_buffer(nb, (uint8_t *)(&hdr),
@@ -403,6 +409,11 @@ int push_cease_mediation_onto_net_buffer(net_buffer_t *nb, char *liid,
 
     if (push_tlv(nb, OPENLI_PROTO_FIELD_LIID, (uint8_t *)(liid),
                 liid_len) == -1) {
+        return -1;
+    }
+
+    if (push_tlv(nb, OPENLI_PROTO_FIELD_AUTHCC, (uint8_t *)(authcc),
+                authcc_len) == -1) {
         return -1;
     }
     return (int)totallen;
@@ -1088,11 +1099,13 @@ pushvoipintfail:
 }
 
 #define SIPTARGET_BODY_LEN_NOREALM(sipid, vint) \
-        (vint->common.liid_len + sipid->username_len + (2 * 4))
+        (vint->common.liid_len + vint->common.authcc_len + \
+        sipid->username_len + (3 * 4))
 
 #define SIPTARGET_BODY_LEN(sipid, vint) \
-        (vint->common.liid_len + sipid->username_len + sipid->realm_len \
-        + (3 * 4))
+        (vint->common.liid_len + vint->common.authcc_len + \
+        sipid->username_len + sipid->realm_len \
+        + (4 * 4))
 
 static inline int push_sip_target_onto_net_buffer_generic(net_buffer_t *nb,
         openli_sip_identity_t *sipid, voipintercept_t *vint,
@@ -1129,6 +1142,11 @@ static inline int push_sip_target_onto_net_buffer_generic(net_buffer_t *nb,
         goto pushsiptargetfail;
     }
 
+    if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_AUTHCC,
+            (uint8_t *)vint->common.authcc, vint->common.authcc_len)) == -1) {
+        goto pushsiptargetfail;
+    }
+
     if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_SIP_USER,
             (uint8_t *)sipid->username, sipid->username_len)) == -1) {
         goto pushsiptargetfail;
@@ -1140,10 +1158,6 @@ static inline int push_sip_target_onto_net_buffer_generic(net_buffer_t *nb,
             goto pushsiptargetfail;
         }
     }
-
-    /* Technically, we should also include authCC in here too for
-     * multi-national operators but that can probably wait for now.
-     */
 
     return (int)totallen;
 
@@ -1175,8 +1189,8 @@ int push_sip_target_withdrawal_onto_net_buffer(net_buffer_t *nb,
 }
 
 #define EMAILTARGET_BODY_LEN(tgt, em) \
-        (em->common.liid_len + strlen(tgt->address) \
-        + (2 * 4))
+        (em->common.liid_len + em->common.authcc_len + strlen(tgt->address) \
+        + (3 * 4))
 
 static inline int push_email_target_onto_net_buffer_generic(net_buffer_t *nb,
         email_target_t *tgt, emailintercept_t *em,
@@ -1209,14 +1223,15 @@ static inline int push_email_target_onto_net_buffer_generic(net_buffer_t *nb,
         goto pushtargetfail;
     }
 
+    if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_AUTHCC,
+            (uint8_t *)em->common.authcc, em->common.authcc_len)) == -1) {
+        goto pushtargetfail;
+    }
+
     if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_EMAIL_TARGET,
             (uint8_t *)tgt->address, strlen(tgt->address))) == -1) {
         goto pushtargetfail;
     }
-
-    /* Technically, we should also include authCC in here too for
-     * multi-national operators but that can probably wait for now.
-     */
 
     return (int)totallen;
 
@@ -1241,9 +1256,10 @@ int push_email_target_withdrawal_onto_net_buffer(net_buffer_t *nb,
             OPENLI_PROTO_WITHDRAW_EMAIL_TARGET);
 }
 
-#define UDPSINK_BODY_LEN(liid, sink) \
+#define UDPSINK_BODY_LEN(common, sink) \
     (strlen(sink->key) + sizeof(sink->direction) + sizeof(sink->encapfmt) + \
-     strlen(liid) + sizeof(sink->cin) + (5 * 4) + \
+     strlen(common->liid) + strlen(common->authcc) + sizeof(sink->cin) + \
+     (6 * 4) + \
      (sink->sourcehost ? strlen(sink->sourcehost) + 4 : 0) + \
      (sink->sourceport ? strlen(sink->sourceport) + 4 : 0))
 
@@ -1259,7 +1275,7 @@ static int push_intercept_udpsink_generic(net_buffer_t *nb,
         return 0;
     }
 
-    totallen = UDPSINK_BODY_LEN(common->liid, sink);
+    totallen = UDPSINK_BODY_LEN(common, sink);
     populate_header(&hdr, msgtype, totallen, 0);
 
     if ((ret = push_generic_onto_net_buffer(nb, (uint8_t *)(&hdr),
@@ -1269,6 +1285,11 @@ static int push_intercept_udpsink_generic(net_buffer_t *nb,
 
     if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_LIID, (uint8_t *)common->liid,
             common->liid_len)) == -1) {
+        goto pushudpsinkfail;
+    }
+
+    if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_AUTHCC,
+            (uint8_t *)common->authcc, common->authcc_len)) == -1) {
         goto pushudpsinkfail;
     }
 
@@ -1335,7 +1356,7 @@ int push_remove_intercept_udp_sink_onto_net_buffer(net_buffer_t *nb,
 
 #define STATICIP_RANGE_BODY_LEN(ipint, ipr) \
         (strlen(ipr->rangestr) + sizeof(ipr->cin) + \
-        ipint->common.liid_len + (3 * 4))
+        ipint->common.liid_len + ipint->common.authcc_len + (4 * 4))
 
 static int push_static_ipranges_generic(net_buffer_t *nb, ipintercept_t *ipint,
         static_ipranges_t *ipr, openli_proto_msgtype_t msgtype) {
@@ -1364,6 +1385,12 @@ static int push_static_ipranges_generic(net_buffer_t *nb, ipintercept_t *ipint,
     if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_LIID,
                     (uint8_t *)ipint->common.liid,
                     ipint->common.liid_len)) == -1) {
+        goto pushstaticipfail;
+    }
+
+    if ((ret = push_tlv(nb, OPENLI_PROTO_FIELD_AUTHCC,
+                    (uint8_t *)ipint->common.authcc,
+                    ipint->common.authcc_len)) == -1) {
         goto pushstaticipfail;
     }
 
@@ -2065,6 +2092,8 @@ static inline void init_decoded_intercept_common(intercept_common_t *common) {
     common->liid = NULL;
     common->authcc = NULL;
     common->delivcc = NULL;
+    common->liid_key = NULL;
+    common->liid_key_len = 0;
     common->destid = 0;
     common->targetagency = NULL;
     common->operatorid = NULL;
@@ -2161,6 +2190,22 @@ static int assign_intercept_common_fields(intercept_common_t *common,
 
 }
 
+static int derive_decoded_liid_key(intercept_common_t *common) {
+    char errbuf[256];
+
+    if (common->liid == NULL || common->authcc == NULL) {
+        return 0;
+    }
+
+    if (set_intercept_liid_key(common, errbuf, sizeof(errbuf)) < 0) {
+        logger(LOG_INFO,
+                "OpenLI: unable to derive internal key for received intercept %s: %s",
+                common->liid, errbuf);
+        return -1;
+    }
+    return 0;
+}
+
 int decode_emailintercept_start(uint8_t *msgbody, uint16_t len,
         emailintercept_t *mailint) {
 
@@ -2202,7 +2247,7 @@ int decode_emailintercept_start(uint8_t *msgbody, uint16_t len,
         msgbody += (vallen + 4);
     }
 
-    return 0;
+    return derive_decoded_liid_key(&(mailint->common));
 }
 
 int decode_emailintercept_halt(uint8_t *msgbody, uint16_t len,
@@ -2263,7 +2308,7 @@ int decode_voipintercept_start(uint8_t *msgbody, uint16_t len,
         msgbody += (vallen + 4);
     }
 
-    return 0;
+    return derive_decoded_liid_key(&(vint->common));
 }
 
 int decode_voipintercept_halt(uint8_t *msgbody, uint16_t len,
@@ -2349,7 +2394,7 @@ int decode_ipintercept_start(uint8_t *msgbody, uint16_t len,
         msgbody += (vallen + 4);
     }
 
-    return 0;
+    return derive_decoded_liid_key(&(ipint->common));
 
 }
 
@@ -2466,9 +2511,12 @@ int decode_mediator_withdraw(uint8_t *msgbody, uint16_t len,
 }
 
 int decode_email_target_announcement(uint8_t *msgbody, uint16_t len,
-        email_target_t *tgt, char *liidspace, int spacelen) {
+        email_target_t *tgt, char *keyspace, int spacelen) {
 
     uint8_t *msgend = msgbody + len;
+    char *liid = NULL, *authcc = NULL;
+    int r = -1;
+
     tgt->address = NULL;
     tgt->awaitingconfirm = 0;
 
@@ -2478,25 +2526,21 @@ int decode_email_target_announcement(uint8_t *msgbody, uint16_t len,
         uint16_t vallen;
 
         if (decode_tlv(msgbody, msgend, &f, &vallen, &valptr) == -1) {
-            return -1;
+            goto decodetargetdone;
         }
 
         if (f == OPENLI_PROTO_FIELD_EMAIL_TARGET) {
             DECODE_STRING_FIELD(tgt->address, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_LIID) {
-            if (vallen >= spacelen) {
-                logger(LOG_INFO,
-                        "OpenLI: not enough space to save LIID from Email target message -- space provided %d, required %u\n", spacelen, vallen);
-                return -1;
-            }
-            strncpy(liidspace, (char *)valptr, vallen);
-            liidspace[vallen] = '\0';
+            DECODE_STRING_FIELD(liid, valptr, vallen);
+        } else if (f == OPENLI_PROTO_FIELD_AUTHCC) {
+            DECODE_STRING_FIELD(authcc, valptr, vallen);
         } else {
             dump_buffer_contents(msgbody, len);
             logger(LOG_INFO,
                 "OpenLI: invalid field in received Email target announcement: %d.",
                 f);
-            return -1;
+            goto decodetargetdone;
         }
         msgbody += (vallen + 4);
     }
@@ -2504,22 +2548,42 @@ int decode_email_target_announcement(uint8_t *msgbody, uint16_t len,
     if (tgt->address == NULL) {
         logger(LOG_INFO,
                 "OpenLI: received a Email target message with no address?");
-        return -1;
+        goto decodetargetdone;
     }
-    return 0;
+
+    if (liid == NULL || authcc == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: received Email target message without an LIID and authCC -- is the provisioner running an older version of OpenLI?");
+        goto decodetargetdone;
+    }
+
+    if (snprintf(keyspace, spacelen, "%s-%s", authcc, liid) >= spacelen) {
+        logger(LOG_INFO,
+                "OpenLI: not enough space to save intercept key from Email target message -- space provided %d\n", spacelen);
+        goto decodetargetdone;
+    }
+    r = 0;
+
+decodetargetdone:
+    free(liid);
+    free(authcc);
+    return r;
 }
 
 int decode_email_target_withdraw(uint8_t *msgbody, uint16_t len,
-        email_target_t *tgt, char *liidspace, int spacelen) {
+        email_target_t *tgt, char *keyspace, int spacelen) {
 
-    return decode_email_target_announcement(msgbody, len, tgt, liidspace,
+    return decode_email_target_announcement(msgbody, len, tgt, keyspace,
             spacelen);
 }
 
 int decode_sip_target_announcement(uint8_t *msgbody, uint16_t len,
-        openli_sip_identity_t *sipid, char *liidspace, int spacelen) {
+        openli_sip_identity_t *sipid, char *keyspace, int spacelen) {
 
     uint8_t *msgend = msgbody + len;
+    char *liid = NULL, *authcc = NULL;
+    int r = -1;
+
     sipid->realm = NULL;
     sipid->realm_len = 0;
     sipid->username = NULL;
@@ -2532,7 +2596,7 @@ int decode_sip_target_announcement(uint8_t *msgbody, uint16_t len,
         uint16_t vallen;
 
         if (decode_tlv(msgbody, msgend, &f, &vallen, &valptr) == -1) {
-            return -1;
+            goto decodesiptargetdone;
         }
 
         if (f == OPENLI_PROTO_FIELD_SIP_USER) {
@@ -2542,19 +2606,15 @@ int decode_sip_target_announcement(uint8_t *msgbody, uint16_t len,
             DECODE_STRING_FIELD(sipid->realm, valptr, vallen);
             sipid->realm_len = strlen(sipid->realm);
         } else if (f == OPENLI_PROTO_FIELD_LIID) {
-            if (vallen >= spacelen) {
-                logger(LOG_INFO,
-                        "OpenLI: not enough space to save LIID from SIP target message -- space provided %d, required %u\n", spacelen, vallen);
-                return -1;
-            }
-            strncpy(liidspace, (char *)valptr, vallen);
-            liidspace[vallen] = '\0';
+            DECODE_STRING_FIELD(liid, valptr, vallen);
+        } else if (f == OPENLI_PROTO_FIELD_AUTHCC) {
+            DECODE_STRING_FIELD(authcc, valptr, vallen);
         } else {
             dump_buffer_contents(msgbody, len);
             logger(LOG_INFO,
                 "OpenLI: invalid field in received SIP target announcement: %d.",
                 f);
-            return -1;
+            goto decodesiptargetdone;
         }
         msgbody += (vallen + 4);
     }
@@ -2562,15 +2622,32 @@ int decode_sip_target_announcement(uint8_t *msgbody, uint16_t len,
     if (sipid->username == NULL) {
         logger(LOG_INFO,
                 "OpenLI: received a SIP target message with no username?");
-        return -1;
+        goto decodesiptargetdone;
     }
-    return 0;
+
+    if (liid == NULL || authcc == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: received SIP target message without an LIID and authCC -- is the provisioner running an older version of OpenLI?");
+        goto decodesiptargetdone;
+    }
+
+    if (snprintf(keyspace, spacelen, "%s-%s", authcc, liid) >= spacelen) {
+        logger(LOG_INFO,
+                "OpenLI: not enough space to save intercept key from SIP target message -- space provided %d\n", spacelen);
+        goto decodesiptargetdone;
+    }
+    r = 0;
+
+decodesiptargetdone:
+    free(liid);
+    free(authcc);
+    return r;
 }
 
 int decode_sip_target_withdraw(uint8_t *msgbody, uint16_t len,
-        openli_sip_identity_t *sipid, char *liidspace, int spacelen) {
+        openli_sip_identity_t *sipid, char *keyspace, int spacelen) {
 
-    return decode_sip_target_announcement(msgbody, len, sipid, liidspace,
+    return decode_sip_target_announcement(msgbody, len, sipid, keyspace,
             spacelen);
 }
 
@@ -2687,6 +2764,7 @@ int decode_intercept_udpsink_announcement(uint8_t *msgbody, uint16_t len,
     sink->encapfmt = INTERCEPT_UDP_ENCAP_FORMAT_RAW;
     sink->direction = ETSI_DIR_INDETERMINATE;
     sink->liid = NULL;
+    sink->authcc = NULL;
     sink->cin = 1;
     sink->sourceport = NULL;
     sink->sourcehost = NULL;
@@ -2707,6 +2785,8 @@ int decode_intercept_udpsink_announcement(uint8_t *msgbody, uint16_t len,
             DECODE_STRING_FIELD(sink->key, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_LIID) {
             DECODE_STRING_FIELD(sink->liid, valptr, vallen);
+        } else if (f == OPENLI_PROTO_FIELD_AUTHCC) {
+            DECODE_STRING_FIELD(sink->authcc, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_ACL_IPADDR) {
             DECODE_STRING_FIELD(sink->sourcehost, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_ACL_PORT) {
@@ -2787,6 +2867,7 @@ int decode_staticip_announcement(uint8_t *msgbody, uint16_t len,
     ipr->rangestr = NULL;
     ipr->awaitingconfirm = 0;
     ipr->liid = NULL;
+    ipr->authcc = NULL;
     ipr->cin = 1;
 
     while (msgbody < msgend) {
@@ -2799,6 +2880,8 @@ int decode_staticip_announcement(uint8_t *msgbody, uint16_t len,
         }
         if (f == OPENLI_PROTO_FIELD_LIID) {
             DECODE_STRING_FIELD(ipr->liid, valptr, vallen);
+        } else if (f == OPENLI_PROTO_FIELD_AUTHCC) {
+            DECODE_STRING_FIELD(ipr->authcc, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_STATICIP_RANGE) {
             DECODE_STRING_FIELD(ipr->rangestr, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_CIN) {
@@ -3139,7 +3222,7 @@ int decode_x2x3_listener(uint8_t *msgbody, uint16_t len, char **addr,
 
 
 int decode_liid_mapping(uint8_t *msgbody, uint16_t len, char **agency,
-        char **liid, uint8_t *encryptkey, size_t *encryptlen,
+        char **liid, char **authcc, uint8_t *encryptkey, size_t *encryptlen,
         payload_encryption_method_t *method, openli_liid_format_t *liidformat) {
 
     uint8_t *msgend = msgbody + len;
@@ -3147,6 +3230,7 @@ int decode_liid_mapping(uint8_t *msgbody, uint16_t len, char **agency,
     *encryptlen = 0;
     *method = OPENLI_PAYLOAD_ENCRYPTION_NOT_SPECIFIED;
     *liidformat = OPENLI_LIID_FORMAT_ASCII;
+    *authcc = NULL;
 
     while (msgbody < msgend) {
         openli_proto_fieldtype_t f;
@@ -3161,6 +3245,8 @@ int decode_liid_mapping(uint8_t *msgbody, uint16_t len, char **agency,
             DECODE_STRING_FIELD(*liid, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_LEAID) {
             DECODE_STRING_FIELD(*agency, valptr, vallen);
+        } else if (f == OPENLI_PROTO_FIELD_AUTHCC) {
+            DECODE_STRING_FIELD(*authcc, valptr, vallen);
         } else if (f == OPENLI_PROTO_FIELD_ENCRYPTION_KEY) {
 			if (vallen > OPENLI_MAX_ENCRYPTKEY_LEN) {
 				logger(LOG_INFO, "OpenLI: encryption key too long for buffer (%u)", vallen);
@@ -3188,11 +3274,20 @@ int decode_liid_mapping(uint8_t *msgbody, uint16_t len, char **agency,
         msgbody += (vallen + 4);
     }
 
+    if (*authcc == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: received LIID mapping without an authCC -- is the provisioner running an older version of OpenLI?");
+        return -1;
+    }
+
     return 0;
 }
 
-int decode_cease_mediation(uint8_t *msgbody, uint16_t len, char **liid) {
+int decode_cease_mediation(uint8_t *msgbody, uint16_t len, char **liid,
+        char **authcc) {
     uint8_t *msgend = msgbody + len;
+
+    *authcc = NULL;
 
     while (msgbody < msgend) {
         openli_proto_fieldtype_t f;
@@ -3205,6 +3300,8 @@ int decode_cease_mediation(uint8_t *msgbody, uint16_t len, char **liid) {
 
         if (f == OPENLI_PROTO_FIELD_LIID) {
             DECODE_STRING_FIELD(*liid, valptr, vallen);
+        } else if (f == OPENLI_PROTO_FIELD_AUTHCC) {
+            DECODE_STRING_FIELD(*authcc, valptr, vallen);
         } else {
             dump_buffer_contents(msgbody, len);
             logger(LOG_INFO,
@@ -3213,6 +3310,12 @@ int decode_cease_mediation(uint8_t *msgbody, uint16_t len, char **liid) {
             return -1;
         }
         msgbody += (vallen + 4);
+    }
+
+    if (*authcc == NULL) {
+        logger(LOG_INFO,
+                "OpenLI: received cease mediation without an authCC -- is the provisioner running an older version of OpenLI?");
+        return -1;
     }
 
     return 0;

--- a/src/netcomms.h
+++ b/src/netcomms.h
@@ -310,10 +310,10 @@ int push_udp_sink_onto_net_buffer(net_buffer_t *nb, const char *addr,
         const char *port, const char *identifier, uint64_t ts,
         openli_proto_msgtype_t msgtype);
 int push_liid_mapping_onto_net_buffer(net_buffer_t *nb, char *agency,
-        char *liid, uint8_t *encryptkey, size_t encryptlen,
+        char *liid, char *authcc, uint8_t *encryptkey, size_t encryptlen,
         payload_encryption_method_t method, openli_liid_format_t liidformat);
 int push_cease_mediation_onto_net_buffer(net_buffer_t *nb, char *liid,
-        int liid_len);
+        int liid_len, char *authcc, int authcc_len);
 int push_disconnect_mediators_onto_net_buffer(net_buffer_t *nb);
 int push_coreserver_onto_net_buffer(net_buffer_t *nb, coreserver_t *cs,
         uint8_t cstype);
@@ -393,26 +393,27 @@ int decode_lea_withdrawal(uint8_t *msgbody, uint16_t len, liagency_t *lea);
 int decode_lea_digest_config(uint8_t *msgbody, uint16_t len, char **agencyid,
         liagency_digest_config_t **digest, char **operatorid);
 int decode_liid_mapping(uint8_t *msgbody, uint16_t len, char **agency,
-        char **liid, uint8_t *encryptkey, size_t *encryptlen,
+        char **liid, char **authcc, uint8_t *encryptkey, size_t *encryptlen,
         payload_encryption_method_t *method,
         openli_liid_format_t *liidformat);
 int decode_udp_sink(uint8_t *msgbody, uint16_t len, char **addr,
         char **port, char **identifier, uint64_t *ts);
 int decode_x2x3_listener(uint8_t *msgbody, uint16_t len, char **addr,
         char **port, uint64_t *ts, uint8_t *isactive);
-int decode_cease_mediation(uint8_t *msgbody, uint16_t len, char **liid);
+int decode_cease_mediation(uint8_t *msgbody, uint16_t len, char **liid,
+        char **authcc);
 int decode_coreserver_announcement(uint8_t *msgbody, uint16_t len,
         coreserver_t *cs);
 int decode_coreserver_withdraw(uint8_t *msgbody, uint16_t len,
         coreserver_t *cs);
 int decode_sip_target_announcement(uint8_t *msgbody, uint16_t len,
-        openli_sip_identity_t *sipid, char *liidspace, int spacelen);
+        openli_sip_identity_t *sipid, char *keyspace, int spacelen);
 int decode_sip_target_withdraw(uint8_t *msgbody, uint16_t len,
-        openli_sip_identity_t *sipid, char *liidspace, int spacelen);
+        openli_sip_identity_t *sipid, char *keyspace, int spacelen);
 int decode_email_target_announcement(uint8_t *msgbody, uint16_t len,
-        email_target_t *tgt, char *liidspace, int spacelen);
+        email_target_t *tgt, char *keyspace, int spacelen);
 int decode_email_target_withdraw(uint8_t *msgbody, uint16_t len,
-        email_target_t *tgt, char *liidspace, int spacelen);
+        email_target_t *tgt, char *keyspace, int spacelen);
 int decode_staticip_announcement(uint8_t *msgbody, uint16_t len,
         static_ipranges_t *ipr);
 int decode_staticip_removal(uint8_t *msgbody, uint16_t len,

--- a/src/provisioner/clientupdates.c
+++ b/src/provisioner/clientupdates.c
@@ -645,7 +645,7 @@ int announce_hi1_notification_to_mediators(provision_state_t *state,
 }
 
 int remove_liid_mapping(provision_state_t *state,
-        char *liid, int liid_len, int droppedmeds) {
+        intercept_common_t *common, int droppedmeds) {
 
     liid_hash_t *found;
     /* Don't need to find and remove the mapping from our LIID map, as
@@ -655,7 +655,8 @@ int remove_liid_mapping(provision_state_t *state,
         return 0;
     }
 
-    HASH_FIND(hh, state->interceptconf.liid_map, liid, strlen(liid), found);
+    HASH_FIND(hh, state->interceptconf.liid_map, common->liid_key,
+            strlen(common->liid_key), found);
     if (found) {
         HASH_DELETE(hh, state->interceptconf.liid_map, found);
         free(found);
@@ -668,11 +669,12 @@ int remove_liid_mapping(provision_state_t *state,
      */
 
         if (push_cease_mediation_onto_net_buffer(sock->outgoing,
-                    liid, liid_len) == -1) {
+                    common->liid, common->liid_len, common->authcc,
+                    common->authcc_len) == -1) {
             if (sock->log_allowed) {
                 logger(LOG_INFO,
                         "OpenLI provisioner: unable to halt mediation of intercept %s on mediator %u.",
-                        liid, med->mediatorid);
+                        common->liid, med->mediatorid);
             }
             disconnect_provisioner_client(state->epoll_fd, med->client,
                     med->details->ipstr);
@@ -706,7 +708,8 @@ int announce_liidmapping_to_mediators(provision_state_t *state,
 
     SEND_ALL_MEDIATORS_BEGIN
         if (push_liid_mapping_onto_net_buffer(sock->outgoing, liidmap->agency,
-                liidmap->liid, liidmap->encryptkey, liidmap->encryptkey_len,
+                liidmap->liid, liidmap->authcc, liidmap->encryptkey,
+                liidmap->encryptkey_len,
                 liidmap->encryptmethod, liidmap->liid_format)
                 == -1) {
             logger(LOG_INFO,
@@ -923,13 +926,17 @@ liid_hash_t *add_liid_mapping(prov_intercept_conf_t *conf,
 
     liid_hash_t *h, *found;
 
-    HASH_FIND(hh, conf->liid_map, common->liid, strlen(common->liid), found);
+    HASH_FIND(hh, conf->liid_map, common->liid_key, strlen(common->liid_key),
+            found);
     if (found) {
         h = found;
     } else {
         h = (liid_hash_t *)malloc(sizeof(liid_hash_t));
         h->liid = common->liid;
-        HASH_ADD_KEYPTR(hh, conf->liid_map, h->liid, strlen(h->liid), h);
+        h->authcc = common->authcc;
+        h->liid_key = common->liid_key;
+        HASH_ADD_KEYPTR(hh, conf->liid_map, h->liid_key, strlen(h->liid_key),
+                h);
     }
     h->liid_format = common->liid_format;
     h->agency = common->targetagency;

--- a/src/provisioner/configparser_provisioner.c
+++ b/src/provisioner/configparser_provisioner.c
@@ -451,6 +451,7 @@ static int add_intercept_static_ips(static_ipranges_t **statics,
         newr = (static_ipranges_t *)malloc(sizeof(static_ipranges_t));
         newr->rangestr = NULL;
         newr->liid = NULL;
+        newr->authcc = NULL;
         newr->awaitingconfirm = 1;
         newr->cin = 1;
 
@@ -991,6 +992,8 @@ static inline void init_intercept_common(intercept_common_t *common,
     common->liid = NULL;
     common->liid_format = OPENLI_LIID_FORMAT_ASCII;
     common->liid_len = 0;
+    common->liid_key = NULL;
+    common->liid_key_len = 0;
     common->authcc = NULL;
     common->authcc_len = 0;
     common->delivcc = NULL;
@@ -1087,8 +1090,16 @@ static int parse_emailintercept_list(emailintercept_t **mailints,
                 tgtcount > 0 &&
                 newcept->common.destid > 0 &&
                 newcept->common.targetagency != NULL) {
-            HASH_ADD_KEYPTR(hh_liid, *mailints, newcept->common.liid,
-                    newcept->common.liid_len, newcept);
+            char keyerr[256];
+            if (set_intercept_liid_key(&(newcept->common), keyerr,
+                    sizeof(keyerr)) < 0) {
+                logger(LOG_INFO, "OpenLI: invalid Email intercept configuration for '%s': %s -- skipping.",
+                        newcept->common.liid, keyerr);
+                free_single_emailintercept(newcept);
+                continue;
+            }
+            HASH_ADD_KEYPTR(hh_liid, *mailints, newcept->common.liid_key,
+                    newcept->common.liid_key_len, newcept);
         } else {
             logger(LOG_INFO, "OpenLI: Email Intercept configuration was incomplete -- skipping.");
             free_single_emailintercept(newcept);
@@ -1160,8 +1171,16 @@ static int parse_voipintercept_list(voipintercept_t **voipints,
                     newcept->common.xid_count > 0) &&
                 newcept->common.destid > 0 &&
                 newcept->common.targetagency != NULL) {
-            HASH_ADD_KEYPTR(hh_liid, *voipints, newcept->common.liid,
-                    newcept->common.liid_len, newcept);
+            char keyerr[256];
+            if (set_intercept_liid_key(&(newcept->common), keyerr,
+                    sizeof(keyerr)) < 0) {
+                logger(LOG_INFO, "OpenLI: invalid VOIP intercept configuration for '%s': %s -- skipping.",
+                        newcept->common.liid, keyerr);
+                free_single_voipintercept(newcept);
+                continue;
+            }
+            HASH_ADD_KEYPTR(hh_liid, *voipints, newcept->common.liid_key,
+                    newcept->common.liid_key_len, newcept);
         } else {
             logger(LOG_INFO, "OpenLI: VOIP Intercept configuration was incomplete -- skipping.");
             free_single_voipintercept(newcept);
@@ -1316,14 +1335,23 @@ static int parse_ipintercept_list(ipintercept_t **ipints, yaml_document_t *doc,
                 newcept->common.destid > 0 &&
                 newcept->common.targetagency != NULL) {
 
+            char keyerr[256];
+            if (set_intercept_liid_key(&(newcept->common), keyerr,
+                    sizeof(keyerr)) < 0) {
+                logger(LOG_INFO, "OpenLI: invalid IP intercept configuration for '%s': %s -- skipping.",
+                        newcept->common.liid, keyerr);
+                free_single_ipintercept(newcept);
+                continue;
+            }
+
             /* Default to matching against both RADIUS username and CSID */
             if (!radchosen) {
                 newcept->options |= (1 << OPENLI_IPINT_OPTION_RADIUS_IDENT_CSID);
                 newcept->options |= (1 << OPENLI_IPINT_OPTION_RADIUS_IDENT_USER);
             }
 
-            HASH_ADD_KEYPTR(hh_liid, *ipints, newcept->common.liid,
-                    newcept->common.liid_len, newcept);
+            HASH_ADD_KEYPTR(hh_liid, *ipints, newcept->common.liid_key,
+                    newcept->common.liid_key_len, newcept);
         } else {
             if (newcept->username == NULL) {
                 logger(LOG_INFO, "OpenLI: provisioner configuration error: 'user' must be specified for an IP intercept");

--- a/src/provisioner/hup_reload.c
+++ b/src/provisioner/hup_reload.c
@@ -480,7 +480,7 @@ static int reload_coreservers(provision_state_t *state, coreserver_t *currserv,
 static void remove_withdrawn_intercept(provision_state_t *currstate,
         intercept_common_t *common, char *target_info, int droppedmeds) {
 
-    remove_liid_mapping(currstate, common->liid, common->liid_len, droppedmeds);
+    remove_liid_mapping(currstate, common, droppedmeds);
     if (!droppedmeds) {
         announce_hi1_notification_to_mediators(currstate,
                 common, target_info, HI1_LI_DEACTIVATED);
@@ -625,8 +625,8 @@ static int reload_emailintercepts(provision_state_t *currstate,
      * functions?
      */
     HASH_ITER(hh_liid, curremail, mailint, tmp) {
-        HASH_FIND(hh_liid, newemail, mailint->common.liid,
-                mailint->common.liid_len, newequiv);
+        HASH_FIND(hh_liid, newemail, mailint->common.liid_key,
+                mailint->common.liid_key_len, newequiv);
 
         if (!newequiv) {
             /* Intercept has been withdrawn entirely */
@@ -765,8 +765,8 @@ static int reload_voipintercepts(provision_state_t *currstate,
      * functions?
      */
     HASH_ITER(hh_liid, currvoip, voipint, tmp) {
-        HASH_FIND(hh_liid, newvoip, voipint->common.liid,
-                voipint->common.liid_len, newequiv);
+        HASH_FIND(hh_liid, newvoip, voipint->common.liid_key,
+                voipint->common.liid_key_len, newequiv);
 
         if (newequiv && currstate->ignorertpcomfort) {
             newequiv->options |= (1 << OPENLI_VOIPINT_OPTION_IGNORE_COMFORT);
@@ -906,8 +906,8 @@ static int reload_ipintercepts(provision_state_t *currstate,
     prov_agency_t *lea;
 
     HASH_ITER(hh_liid, currints, ipint, tmp) {
-        HASH_FIND(hh_liid, newints, ipint->common.liid,
-                ipint->common.liid_len, newequiv);
+        HASH_FIND(hh_liid, newints, ipint->common.liid_key,
+                ipint->common.liid_key_len, newequiv);
 
         if (!newequiv) {
             /* Intercept has been withdrawn entirely */

--- a/src/provisioner/provisioner.c
+++ b/src/provisioner/provisioner.c
@@ -190,7 +190,7 @@ static int liid_hash_sort(liid_hash_t *a, liid_hash_t *b) {
     if (x != 0) {
         return x;
     }
-    return strcmp(a->liid, b->liid);
+    return strcmp(a->liid_key, b->liid_key);
 }
 
 int map_intercepts_to_leas(prov_intercept_conf_t *conf) {
@@ -1284,7 +1284,7 @@ static int respond_mediator_auth(provision_state_t *state,
     h = state->interceptconf.liid_map;
     while (h != NULL) {
         if (push_liid_mapping_onto_net_buffer(outgoing, h->agency, h->liid,
-                h->encryptkey, h->encryptkey_len, h->encryptmethod,
+                h->authcc, h->encryptkey, h->encryptkey_len, h->encryptmethod,
                 h->liid_format) == -1) {
             logger(LOG_INFO,
                     "OpenLI: error while buffering LIID mappings to send to mediator.");

--- a/src/provisioner/provisioner.h
+++ b/src/provisioner/provisioner.h
@@ -175,6 +175,10 @@ typedef struct liid_hash {
     char *agency;
     /** The LIID for the intercept */
     char *liid;
+    /** The authorising country code for the intercept */
+    char *authcc;
+    /** The authCC-qualified intercept key ("<authcc>-<liid>") */
+    char *liid_key;
 
     /** Whether the LIID is ascii-text or binary octets */
     openli_liid_format_t liid_format;
@@ -525,7 +529,7 @@ int modify_existing_intercept_options(provision_state_t *state,
         void *cept, openli_proto_msgtype_t modtype);
 int disconnect_mediators_from_collectors(provision_state_t *state);
 int remove_liid_mapping(provision_state_t *state,
-        char *liid, int liid_len, int droppedmeds);
+        intercept_common_t *common, int droppedmeds);
 int announce_liidmapping_to_mediators(provision_state_t *state,
         liid_hash_t *liidmap);
 int announce_coreserver_change(provision_state_t *state,

--- a/src/provisioner/updateserver.h
+++ b/src/provisioner/updateserver.h
@@ -49,6 +49,28 @@ typedef struct con_info {
 
 } update_con_info_t;
 
+#define FIND_INTERCEPT_BY_ID(cepttype, table, idstr, found, ambiguous) \
+    do { \
+        cepttype *cand_, *tmp_; \
+        int matches_ = 0; \
+        (found) = NULL; \
+        (ambiguous) = 0; \
+        HASH_FIND(hh_liid, (table), (idstr), strlen((idstr)), (found)); \
+        if ((found) == NULL) { \
+            HASH_ITER(hh_liid, (table), cand_, tmp_) { \
+                if (strcmp(cand_->common.liid, (idstr)) != 0) { \
+                    continue; \
+                } \
+                matches_ ++; \
+                (found) = cand_; \
+            } \
+            if (matches_ > 1) { \
+                (found) = NULL; \
+                (ambiguous) = matches_; \
+            } \
+        } \
+    } while (0)
+
 enum {
     TARGET_AGENCY,
     TARGET_SIPSERVER,

--- a/src/provisioner/updateserver_jsoncreation.c
+++ b/src/provisioner/updateserver_jsoncreation.c
@@ -767,10 +767,22 @@ json_object *get_voip_intercept(update_con_info_t *cinfo UNUSED,
 
     voipintercept_t *vint, *tmp;
     json_object *jarray, *jobj;
+    int ambiguous = 0;
 
     if (target) {
-        HASH_FIND(hh_liid, state->interceptconf.voipintercepts, target,
-                strlen(target), vint);
+        FIND_INTERCEPT_BY_ID(voipintercept_t,
+                state->interceptconf.voipintercepts, target, vint, ambiguous);
+        if (ambiguous) {
+            jarray = json_object_new_array();
+            HASH_ITER(hh_liid, state->interceptconf.voipintercepts, vint,
+                    tmp) {
+                if (strcmp(vint->common.liid, target) == 0) {
+                    json_object_array_add(jarray,
+                            convert_voipintercept_to_json(vint));
+                }
+            }
+            return jarray;
+        }
         if (!vint) {
             return NULL;
         }
@@ -793,10 +805,23 @@ json_object *get_email_intercept(update_con_info_t *cinfo UNUSED,
 
     emailintercept_t *mailint, *tmp;
     json_object *jarray, *jobj;
+    int ambiguous = 0;
 
     if (target) {
-        HASH_FIND(hh_liid, state->interceptconf.emailintercepts, target,
-                strlen(target), mailint);
+        FIND_INTERCEPT_BY_ID(emailintercept_t,
+                state->interceptconf.emailintercepts, target, mailint,
+                ambiguous);
+        if (ambiguous) {
+            jarray = json_object_new_array();
+            HASH_ITER(hh_liid, state->interceptconf.emailintercepts, mailint,
+                    tmp) {
+                if (strcmp(mailint->common.liid, target) == 0) {
+                    json_object_array_add(jarray,
+                            convert_emailintercept_to_json(mailint));
+                }
+            }
+            return jarray;
+        }
         if (!mailint) {
             return NULL;
         }
@@ -819,10 +844,21 @@ json_object *get_ip_intercept(update_con_info_t *cinfo UNUSED,
 
     ipintercept_t *ipint, *tmp;
     json_object *jarray, *jobj;
+    int ambiguous = 0;
 
     if (target) {
-        HASH_FIND(hh_liid, state->interceptconf.ipintercepts, target,
-                strlen(target), ipint);
+        FIND_INTERCEPT_BY_ID(ipintercept_t,
+                state->interceptconf.ipintercepts, target, ipint, ambiguous);
+        if (ambiguous) {
+            jarray = json_object_new_array();
+            HASH_ITER(hh_liid, state->interceptconf.ipintercepts, ipint, tmp) {
+                if (strcmp(ipint->common.liid, target) == 0) {
+                    json_object_array_add(jarray,
+                            convert_ipintercept_to_json(ipint));
+                }
+            }
+            return jarray;
+        }
         if (!ipint) {
             return NULL;
         }

--- a/src/provisioner/updateserver_jsonparsing.c
+++ b/src/provisioner/updateserver_jsonparsing.c
@@ -534,6 +534,12 @@ static int parse_intercept_common_json(struct json_intercept *jsonp,
         common->liid_len = strlen(common->liid);
     }
 
+    if (common->liid && common->authcc) {
+        if (set_intercept_liid_key(common, cinfo->answerstring, 4096) < 0) {
+            return -1;
+        }
+    }
+
 	if (is_new) {
 		if (common->encrypt != OPENLI_PAYLOAD_ENCRYPTION_NONE &&
                 common->encrypt != OPENLI_PAYLOAD_ENCRYPTION_NOT_SPECIFIED) {
@@ -611,6 +617,13 @@ static int update_intercept_common(intercept_common_t *parsed,
         }
     }
 
+    if (parsed->authcc && strcmp(parsed->authcc, existing->authcc) != 0) {
+        snprintf(cinfo->answerstring, 4096,
+                "the 'authcc' of an existing intercept cannot be modified -- withdraw intercept %s and create a new one instead",
+                existing->liid);
+        return -1;
+    }
+
     if (compare_xid_list(parsed, existing) != 0) {
         *changed = 1;
         free(existing->xids);
@@ -620,8 +633,6 @@ static int update_intercept_common(intercept_common_t *parsed,
         parsed->xid_count = 0;
     }
 
-    MODIFY_STRING_MEMBER(parsed->authcc, existing->authcc, changed);
-    existing->authcc_len  = strlen(existing->authcc);
     MODIFY_STRING_MEMBER(parsed->delivcc, existing->delivcc, changed);
     existing->delivcc_len  = strlen(existing->delivcc);
 
@@ -681,21 +692,30 @@ static int update_intercept_common(intercept_common_t *parsed,
     return 0;
 }
 
-int remove_voip_intercept(update_con_info_t *cinfo UNUSED,
+int remove_voip_intercept(update_con_info_t *cinfo,
         provision_state_t *state, const char *idstr, uint8_t send_deactivate) {
 
     voipintercept_t *found;
     char *target_info;
+    int ambiguous = 0;
 
-    HASH_FIND(hh_liid, state->interceptconf.voipintercepts, idstr,
-            strlen(idstr), found);
+    FIND_INTERCEPT_BY_ID(voipintercept_t, state->interceptconf.voipintercepts,
+            idstr, found, ambiguous);
+
+    if (ambiguous) {
+        snprintf(cinfo->answerstring, 4096,
+                "%s <p>%d VOIP intercepts exist with the LIID %s -- specify the intercept to remove as '&lt;authcc&gt;-&lt;liid&gt;'. %s",
+                update_failure_page_start, ambiguous, idstr,
+                update_failure_page_end);
+        cinfo->answercode = MHD_HTTP_CONFLICT;
+        return 0;
+    }
 
     if (found) {
         HASH_DELETE(hh_liid, state->interceptconf.voipintercepts, found);
         halt_existing_intercept(state, (void *)found,
                 OPENLI_PROTO_HALT_VOIPINTERCEPT);
-        remove_liid_mapping(state, found->common.liid, found->common.liid_len,
-                0);
+        remove_liid_mapping(state, &(found->common), 0);
         target_info = list_sip_targets(found, 256);
         if (send_deactivate) {
             announce_hi1_notification_to_mediators(state, &(found->common),
@@ -714,21 +734,30 @@ int remove_voip_intercept(update_con_info_t *cinfo UNUSED,
     return 0;
 }
 
-int remove_email_intercept(update_con_info_t *cinfo UNUSED,
+int remove_email_intercept(update_con_info_t *cinfo,
         provision_state_t *state, const char *idstr, uint8_t send_deactivate) {
 
     emailintercept_t *found;
     char *target_info;
+    int ambiguous = 0;
 
-    HASH_FIND(hh_liid, state->interceptconf.emailintercepts, idstr,
-            strlen(idstr), found);
+    FIND_INTERCEPT_BY_ID(emailintercept_t,
+            state->interceptconf.emailintercepts, idstr, found, ambiguous);
+
+    if (ambiguous) {
+        snprintf(cinfo->answerstring, 4096,
+                "%s <p>%d Email intercepts exist with the LIID %s -- specify the intercept to remove as '&lt;authcc&gt;-&lt;liid&gt;'. %s",
+                update_failure_page_start, ambiguous, idstr,
+                update_failure_page_end);
+        cinfo->answercode = MHD_HTTP_CONFLICT;
+        return 0;
+    }
 
     if (found) {
         HASH_DELETE(hh_liid, state->interceptconf.emailintercepts, found);
         halt_existing_intercept(state, (void *)found,
                 OPENLI_PROTO_HALT_EMAILINTERCEPT);
-        remove_liid_mapping(state, found->common.liid, found->common.liid_len,
-                0);
+        remove_liid_mapping(state, &(found->common), 0);
         target_info = list_email_targets(found, 256);
         if (send_deactivate) {
             announce_hi1_notification_to_mediators(state, &(found->common),
@@ -747,13 +776,24 @@ int remove_email_intercept(update_con_info_t *cinfo UNUSED,
     return 0;
 }
 
-int remove_ip_intercept(update_con_info_t *cinfo UNUSED,
+int remove_ip_intercept(update_con_info_t *cinfo,
         provision_state_t *state, const char *idstr, uint8_t send_deactivate) {
 
     ipintercept_t *found;
+    int ambiguous = 0;
 
-    HASH_FIND(hh_liid, state->interceptconf.ipintercepts, idstr,
-            strlen(idstr), found);
+    FIND_INTERCEPT_BY_ID(ipintercept_t, state->interceptconf.ipintercepts,
+            idstr, found, ambiguous);
+
+    if (ambiguous) {
+        snprintf(cinfo->answerstring, 4096,
+                "%s <p>%d IP intercepts exist with the LIID %s -- specify the intercept to remove as '&lt;authcc&gt;-&lt;liid&gt;'. %s",
+                update_failure_page_start, ambiguous, idstr,
+                update_failure_page_end);
+        cinfo->answercode = MHD_HTTP_CONFLICT;
+        return 0;
+    }
+
     if (!found) {
         return 0;
     }
@@ -767,8 +807,7 @@ int remove_ip_intercept(update_con_info_t *cinfo UNUSED,
     HASH_DELETE(hh_liid, state->interceptconf.ipintercepts, found);
     halt_existing_intercept(state, (void *)found,
             OPENLI_PROTO_HALT_IPINTERCEPT);
-    remove_liid_mapping(state, found->common.liid, found->common.liid_len,
-            0);
+    remove_liid_mapping(state, &(found->common), 0);
     if (send_deactivate) {
         announce_hi1_notification_to_mediators(state, &(found->common),
                 found->username, HI1_LI_DEACTIVATED);
@@ -802,7 +841,7 @@ int remove_agency(update_con_info_t *cinfo, provision_state_t *state,
                 // Will perform another hash lookup, but that's not a big
                 // deal in the overall scheme of things
                 logger(LOG_INFO, "OpenLI: removing email intercept '%s' as its parent agency '%s' has been removed", mailint->common.liid, idstr);
-                remove_email_intercept(cinfo, state, mailint->common.liid, 0);
+                remove_email_intercept(cinfo, state, mailint->common.liid_key, 0);
             }
         }
 
@@ -812,7 +851,7 @@ int remove_agency(update_con_info_t *cinfo, provision_state_t *state,
                 // Will perform another hash lookup, but that's not a big
                 // deal in the overall scheme of things
                 logger(LOG_INFO, "OpenLI: removing VoIP intercept '%s' as its parent agency '%s' has been removed", vint->common.liid, idstr);
-                remove_voip_intercept(cinfo, state, vint->common.liid, 0);
+                remove_voip_intercept(cinfo, state, vint->common.liid_key, 0);
             }
         }
 
@@ -822,7 +861,7 @@ int remove_agency(update_con_info_t *cinfo, provision_state_t *state,
                 // Will perform another hash lookup, but that's not a big
                 // deal in the overall scheme of things
                 logger(LOG_INFO, "OpenLI: removing IP intercept '%s' as its parent agency '%s' has been removed", ipint->common.liid, idstr);
-                remove_ip_intercept(cinfo, state, ipint->common.liid, 0);
+                remove_ip_intercept(cinfo, state, ipint->common.liid_key, 0);
             }
         }
 
@@ -1750,6 +1789,7 @@ static int parse_ipintercept_staticips(ipintercept_t *ipint,
         newr = (static_ipranges_t *)malloc(sizeof(static_ipranges_t));
         newr->rangestr = NULL;
         newr->liid = NULL;
+        newr->authcc = NULL;
         newr->awaitingconfirm = 1;
         newr->cin = 1;
 
@@ -1921,19 +1961,19 @@ int add_new_emailintercept(update_con_info_t *cinfo, provision_state_t *state) {
     }
 
     HASH_FIND(hh_liid, state->interceptconf.emailintercepts,
-            mailint->common.liid, mailint->common.liid_len, found);
+            mailint->common.liid_key, mailint->common.liid_key_len, found);
 
     if (found) {
         snprintf(cinfo->answerstring, 4096,
-                "%s <p>LIID %s already exists as an Email intercept, please use PUT method if you wish to modify it. %s",
+                "%s <p>LIID %s already exists as an Email intercept for authCC %s, please use PUT method if you wish to modify it. %s",
                 update_failure_page_start,
-                mailint->common.liid,
+                mailint->common.liid, mailint->common.authcc,
                 update_failure_page_end);
         goto cepterr;
     }
 
     HASH_ADD_KEYPTR(hh_liid, state->interceptconf.emailintercepts,
-            mailint->common.liid, mailint->common.liid_len, mailint);
+            mailint->common.liid_key, mailint->common.liid_key_len, mailint);
 
 
     new_intercept_liidmapping(state, &(mailint->common));
@@ -2057,19 +2097,19 @@ int add_new_voipintercept(update_con_info_t *cinfo, provision_state_t *state) {
     }
 
     HASH_FIND(hh_liid, state->interceptconf.voipintercepts,
-            vint->common.liid, vint->common.liid_len, found);
+            vint->common.liid_key, vint->common.liid_key_len, found);
 
     if (found) {
         snprintf(cinfo->answerstring, 4096,
-                "%s <p>LIID %s already exists as an VOIP intercept, please use PUT method if you wish to modify it. %s",
+                "%s <p>LIID %s already exists as an VOIP intercept for authCC %s, please use PUT method if you wish to modify it. %s",
                 update_failure_page_start,
-                vint->common.liid,
+                vint->common.liid, vint->common.authcc,
                 update_failure_page_end);
         goto cepterr;
     }
 
     HASH_ADD_KEYPTR(hh_liid, state->interceptconf.voipintercepts,
-            vint->common.liid, vint->common.liid_len, vint);
+            vint->common.liid_key, vint->common.liid_key_len, vint);
 
     new_intercept_liidmapping(state, &(vint->common));
 
@@ -2231,19 +2271,19 @@ int add_new_ipintercept(update_con_info_t *cinfo, provision_state_t *state) {
     }
 
     HASH_FIND(hh_liid, state->interceptconf.ipintercepts,
-            ipint->common.liid, ipint->common.liid_len, found);
+            ipint->common.liid_key, ipint->common.liid_key_len, found);
 
     if (found) {
         snprintf(cinfo->answerstring, 4096,
-                "%s <p>LIID %s already exists as an IP intercept, please use PUT method if you wish to modify it. %s",
+                "%s <p>LIID %s already exists as an IP intercept for authCC %s, please use PUT method if you wish to modify it. %s",
                 update_failure_page_start,
-                ipint->common.liid,
+                ipint->common.liid, ipint->common.authcc,
                 update_failure_page_end);
         goto cepterr;
     }
 
     HASH_ADD_KEYPTR(hh_liid, state->interceptconf.ipintercepts,
-            ipint->common.liid, ipint->common.liid_len, ipint);
+            ipint->common.liid_key, ipint->common.liid_key_len, ipint);
 
     new_intercept_liidmapping(state, &(ipint->common));
 
@@ -2451,7 +2491,7 @@ int modify_emailintercept(update_con_info_t *cinfo, provision_state_t *state) {
     char *target_info;
     char *delivcompressstring = NULL;
 
-    char *liidstr = NULL, *parsedliid = NULL;
+    char *liidstr = NULL, *parsedliid = NULL, *authccstr = NULL;
     int parseerr = 0, changed = 0, agencychanged = 0, timeschanged = 0;
 
     INIT_JSON_INTERCEPT_PARSING
@@ -2470,8 +2510,29 @@ int modify_emailintercept(update_con_info_t *cinfo, provision_state_t *state) {
         parsedliid = liidstr;
     }
 
-    HASH_FIND(hh_liid, state->interceptconf.emailintercepts, parsedliid,
-            strlen(parsedliid), found);
+    EXTRACT_JSON_STRING_PARAM("authcc", "Email intercept", emailjson.authcc,
+            authccstr, &parseerr, false);
+    if (authccstr) {
+        char keybuf[2048];
+        snprintf(keybuf, sizeof(keybuf), "%s-%s", authccstr, parsedliid);
+        HASH_FIND(hh_liid, state->interceptconf.emailintercepts, keybuf,
+                strlen(keybuf), found);
+        free(authccstr);
+        authccstr = NULL;
+    } else {
+        int ambiguous = 0;
+        FIND_INTERCEPT_BY_ID(emailintercept_t,
+                state->interceptconf.emailintercepts, parsedliid, found,
+                ambiguous);
+        if (ambiguous) {
+            snprintf(cinfo->answerstring, 4096,
+                    "%s <p>%d Email intercepts exist with the LIID %s -- an 'authcc' must be provided to identify the intercept to modify. %s",
+                    update_failure_page_start, ambiguous, parsedliid,
+                    update_failure_page_end);
+            free(liidstr);
+            goto cepterr;
+        }
+    }
 
     if (!found) {
         json_object_put(parsed);
@@ -2618,6 +2679,7 @@ int modify_voipintercept(update_con_info_t *cinfo, provision_state_t *state) {
     libtrace_list_t *tmp;
 
     char *liidstr = NULL, *target_info, *parsedliid = NULL;
+    char *authccstr = NULL;
     int changed = 0, agencychanged = 0, parseerr = 0;
     int timeschanged = 0;
 
@@ -2637,8 +2699,29 @@ int modify_voipintercept(update_con_info_t *cinfo, provision_state_t *state) {
         parsedliid = liidstr;
     }
 
-    HASH_FIND(hh_liid, state->interceptconf.voipintercepts, parsedliid,
-            strlen(parsedliid), found);
+    EXTRACT_JSON_STRING_PARAM("authcc", "VOIP intercept", voipjson.authcc,
+            authccstr, &parseerr, false);
+    if (authccstr) {
+        char keybuf[2048];
+        snprintf(keybuf, sizeof(keybuf), "%s-%s", authccstr, parsedliid);
+        HASH_FIND(hh_liid, state->interceptconf.voipintercepts, keybuf,
+                strlen(keybuf), found);
+        free(authccstr);
+        authccstr = NULL;
+    } else {
+        int ambiguous = 0;
+        FIND_INTERCEPT_BY_ID(voipintercept_t,
+                state->interceptconf.voipintercepts, parsedliid, found,
+                ambiguous);
+        if (ambiguous) {
+            snprintf(cinfo->answerstring, 4096,
+                    "%s <p>%d VOIP intercepts exist with the LIID %s -- an 'authcc' must be provided to identify the intercept to modify. %s",
+                    update_failure_page_start, ambiguous, parsedliid,
+                    update_failure_page_end);
+            free(liidstr);
+            goto cepterr;
+        }
+    }
 
     if (!found) {
         json_object_put(parsed);
@@ -2766,6 +2849,7 @@ int modify_ipintercept(update_con_info_t *cinfo, provision_state_t *state) {
     ipintercept_t *ipint = NULL;
 
     char *liidstr = NULL, *parsedliid = NULL;
+    char *authccstr = NULL;
     char *accessstring = NULL;
     char *radiusidentstring = NULL;
     char *mobileidentstring = NULL;
@@ -2788,8 +2872,29 @@ int modify_ipintercept(update_con_info_t *cinfo, provision_state_t *state) {
         parsedliid = liidstr;
     }
 
-    HASH_FIND(hh_liid, state->interceptconf.ipintercepts, parsedliid,
-            strlen(parsedliid), found);
+    EXTRACT_JSON_STRING_PARAM("authcc", "IP intercept", ipjson.authcc,
+            authccstr, &parseerr, false);
+    if (authccstr) {
+        char keybuf[2048];
+        snprintf(keybuf, sizeof(keybuf), "%s-%s", authccstr, parsedliid);
+        HASH_FIND(hh_liid, state->interceptconf.ipintercepts, keybuf,
+                strlen(keybuf), found);
+        free(authccstr);
+        authccstr = NULL;
+    } else {
+        int ambiguous = 0;
+        FIND_INTERCEPT_BY_ID(ipintercept_t,
+                state->interceptconf.ipintercepts, parsedliid, found,
+                ambiguous);
+        if (ambiguous) {
+            snprintf(cinfo->answerstring, 4096,
+                    "%s <p>%d IP intercepts exist with the LIID %s -- an 'authcc' must be provided to identify the intercept to modify. %s",
+                    update_failure_page_start, ambiguous, parsedliid,
+                    update_failure_page_end);
+            free(liidstr);
+            goto cepterr;
+        }
+    }
 
     if (!found) {
         json_object_put(parsed);

--- a/src/tests/test_intercept_liid_key.c
+++ b/src/tests/test_intercept_liid_key.c
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright (c) 2026 SearchLight Ltd, New Zealand.
+ * All rights reserved.
+ *
+ * This file is part of OpenLI.
+ *
+ * OpenLI was originally developed by the University of Waikato WAND
+ * research group. For further information please see http://www.wand.net.nz/
+ *
+ * OpenLI is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenLI is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+/* Unit tests for set_intercept_liid_key() */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "intercept.h"
+
+static int failures = 0;
+
+#define TEST_ASSERT(cond, msg) \
+    do { \
+        if (!(cond)) { \
+            fprintf(stderr, "FAIL: %s (line %d)\n", msg, __LINE__); \
+            failures ++; \
+        } \
+    } while (0)
+
+static void reset_common(intercept_common_t *common, const char *liid,
+        const char *authcc) {
+
+    memset(common, 0, sizeof(intercept_common_t));
+    if (liid) {
+        common->liid = strdup(liid);
+    }
+    if (authcc) {
+        common->authcc = strdup(authcc);
+    }
+}
+
+static void clear_common(intercept_common_t *common) {
+    free(common->liid);
+    free(common->authcc);
+    free(common->liid_key);
+}
+
+int main(void) {
+    intercept_common_t common;
+    char errbuf[256];
+    int ret;
+
+    reset_common(&common, "LIID1", "NZ");
+    ret = set_intercept_liid_key(&common, errbuf, sizeof(errbuf));
+    TEST_ASSERT(ret == 1, "derivation for a valid LIID + authCC failed");
+    TEST_ASSERT(common.liid_key != NULL &&
+            strcmp(common.liid_key, "NZ-LIID1") == 0,
+            "derived key does not match expected '<authcc>-<liid>' form");
+    TEST_ASSERT(common.liid_key_len == (int)strlen("NZ-LIID1"),
+            "derived key length is incorrect");
+
+    free(common.authcc);
+    common.authcc = strdup("AU");
+    ret = set_intercept_liid_key(&common, errbuf, sizeof(errbuf));
+    TEST_ASSERT(ret == 1, "re-derivation after an authCC change failed");
+    TEST_ASSERT(strcmp(common.liid_key, "AU-LIID1") == 0,
+            "re-derived key was not updated to use the new authCC");
+    clear_common(&common);
+
+    reset_common(&common, "LI-ID-2", "NZ");
+    ret = set_intercept_liid_key(&common, errbuf, sizeof(errbuf));
+    TEST_ASSERT(ret == 1, "derivation for an LIID containing '-' failed");
+    TEST_ASSERT(strcmp(common.liid_key, "NZ-LI-ID-2") == 0,
+            "derived key mangled an LIID containing '-'");
+    clear_common(&common);
+
+    reset_common(&common, "D", "AB-C");
+    ret = set_intercept_liid_key(&common, errbuf, sizeof(errbuf));
+    TEST_ASSERT(ret == -1, "an authCC containing '-' was not rejected");
+    TEST_ASSERT(common.liid_key == NULL,
+            "a key was derived despite the authCC being invalid");
+    clear_common(&common);
+
+    reset_common(&common, "LIID3", NULL);
+    ret = set_intercept_liid_key(&common, errbuf, sizeof(errbuf));
+    TEST_ASSERT(ret == -1, "a missing authCC was not rejected");
+    clear_common(&common);
+
+    reset_common(&common, NULL, "NZ");
+    ret = set_intercept_liid_key(&common, errbuf, sizeof(errbuf));
+    TEST_ASSERT(ret == -1, "a missing LIID was not rejected");
+    clear_common(&common);
+
+    if (failures) {
+        fprintf(stderr, "%d test(s) failed\n", failures);
+        return 1;
+    }
+    printf("all tests passed\n");
+    return 0;
+}
+
+// vim: set sw=4 tabstop=4 softtabstop=4 expandtab :


### PR DESCRIPTION
LIIDs are only required to be unique within an authorising country, but OpenLI keys almost every internal lookup, queue name and routing decision on the LIID alone, so two LEAs in different jurisdictions requesting concurrent intercepts with the same LIID would collide.

This PR adds a derived internal key, `liid_key` (`"<authcc>-<liid>"`), to `intercept_common_t`, and uses it as the internal intercept identifier throughout. The LIID encoded into the ETSI records and reported in HI1 notifications is unchanged — nothing an agency sees is affected. An authCC containing the `-` separator is rejected, since `("AB-C", "D")` and `("AB", "C-D")` would otherwise derive the same key; ETSI TS 102 232-1 requires an ISO 3166-1 alpha-2 code there, so this rejects nothing that was previously valid.

### Provisioner

* The three intercept tables and the LIID→agency map are keyed by `liid_key`, so duplicate-LIID detection is per authorising country.
* The REST API accepts either `<authcc>-<liid>` or a bare LIID when identifying an intercept. A bare LIID is accepted when it matches a single intercept; when ambiguous, GET returns all matches and DELETE responds 409 Conflict.
* The authCC of an existing intercept can no longer be modified in place, as it now forms part of the intercept identity — withdraw and recreate instead.

### Protocol

* LIID mappings, cease mediation instructions, SIP and email target (de)announcements, static IP range messages and per-intercept UDP sink messages all carry the authCC alongside the LIID (this also resolves the existing "should include authCC" TODO comments on some of those messages).
* Decoders treat a missing authCC as an error, so a mixed-version deployment fails closed instead of mis-routing records.

### Collector

* Worker intercept maps, session/stream keys, sequence number tracking (including the CIN state database), encoder state, integrity check chains and timed intercept events all key on `liid_key`.
* The length-prefixed preamble on every exported record now carries `liid_key` so the mediator can route on it; the LIID encoded into the ETSI records themselves is unchanged. Integrity check records explicitly track the bare LIID so their PS headers never contain the internal key.

### Mediator

* LIID→agency mappings, per-collector known-LIID state and the internal RabbitMQ queue names all use `liid_key`, which follows naturally from the record preamble.
* **Known limitation:** pcap file outputs remain keyed on the bare LIID, because the ETSI CC writing path can only recover the LIID from the record itself and libwandder does not currently expose an authCC getter. A warning is logged if two pcapdisk intercepts ever share an LIID. Happy to follow up with a `wandder_etsili_get_authcc()` in libwandder so this case can be closed properly.

### Deployment note

All three components must be upgraded together: older mediators and collectors reject the new message formats, and the record preamble format has changed.

### Testing

* New unit test for the key derivation (derivation, re-derivation after a field change, `-` characters within an LIID preserved, separator-in-authCC and missing-field rejection), wired up via `make check` — I believe this is the first `check_PROGRAMS` test in the repo, so the Makefile.am plumbing is new too.
* Clean build with zero warnings under `-Wall -Wextra`.
* Two-jurisdiction end-to-end: two concurrent static IP intercepts sharing the LIID (authCC `NZ` and `AU`, different agencies). Both accepted by the provisioner; each agency's handover received only its own traffic (40/0 packet split on each side), with the correct bare LIID in every PS header and no qualified-key bytes visible on either handover.
* Selective cease: deleting the AU intercept mid-run and replaying traffic delivered further packets only on the NZ handover.
* REST behaviour: GET with the bare shared LIID returns both intercepts, GET `NZ-LIID1` returns one, DELETE with the bare LIID returns 409, DELETE `AU-LIID1` returns 200.

Closes #118.